### PR TITLE
Fixed Upload Plugin Zip File & Exclusion File issue

### DIFF
--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -468,10 +468,16 @@ class InfiniteUploads {
      * Tear down the hooks, url filtering etc for Infinite Uploads
      */
     public function tear_down() {
-        remove_filter( 'upload_dir', [ $this, 'filter_upload_dir' ] );
+        // Priority must match the value used in add_filter() — without it remove_filter() silently fails.
+        remove_filter( 'upload_dir', [ $this, 'filter_upload_dir' ], 1 );
         remove_filter( 'wp_image_editors', [ $this, 'filter_editors' ], 9 );
         remove_filter( 'pre_wp_unique_filename_file_list', [ $this, 'get_files_for_unique_filename_file_list' ], 10 );
         remove_action( 'delete_attachment', [ $this, 'delete_attachment_files' ] );
+
+        // Unregister the iu:// stream wrapper so plugin/theme ZIPs are never routed through cloud storage.
+        if ( in_array( 'iu', stream_get_wrappers(), true ) ) {
+            stream_wrapper_unregister( 'iu' );
+        }
     }
 
     public function get_sync_stats() {
@@ -1299,13 +1305,13 @@ add_action( 'admin_init', '\ClikIT\InfiniteUploads\wc_iu_export_fix' );
 function wc_iu_export_fix() {
     if ( defined( 'DOING_AJAX' ) && DOING_AJAX && current_user_can( 'manage_options' ) ) {
         if ( isset( $_POST['action'] ) && $_POST['action'] == 'woocommerce_do_ajax_product_export' && class_exists( '\ClikIT\InfiniteUploads\InfiniteUploads' ) ) {
-            remove_filter( 'upload_dir', array( InfiniteUploads::get_instance(), 'filter_upload_dir' ) );
+            remove_filter( 'upload_dir', array( InfiniteUploads::get_instance(), 'filter_upload_dir' ), 1 );
         }
     }
 
     if ( isset( $_GET['page'] ) && $_GET['page'] == 'product_exporter' ) {
         if ( class_exists( '\ClikIT\InfiniteUploads\InfiniteUploads' ) ) {
-            remove_filter( 'upload_dir', array( InfiniteUploads::get_instance(), 'filter_upload_dir' ) );
+            remove_filter( 'upload_dir', array( InfiniteUploads::get_instance(), 'filter_upload_dir' ), 1 );
         }
     }
 }
@@ -1404,7 +1410,7 @@ add_filter( 'wpforo_working_folders', '\ClikIT\InfiniteUploads\psx_wpforo_init',
  */
 function psx_wpdiscuz_init() {
     if ( ( class_exists( 'WpdiscuzCore' ) && is_single() ) || defined( 'PT_CV_PATH' ) ) {
-        remove_filter( 'upload_dir', array( InfiniteUploads::get_instance(), 'filter_upload_dir' ) );
+        remove_filter( 'upload_dir', array( InfiniteUploads::get_instance(), 'filter_upload_dir' ), 1 );
     }
 }
 

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -474,6 +474,15 @@ class InfiniteUploads {
         remove_filter( 'pre_wp_unique_filename_file_list', [ $this, 'get_files_for_unique_filename_file_list' ], 10 );
         remove_action( 'delete_attachment', [ $this, 'delete_attachment_files' ] );
 
+        // Remove file-exclusion upload filters. Plugin/theme ZIP installs go through
+        // wp_handle_upload() which fires these filters. Without removing them,
+        // handle_upload() converts the local ZIP path to iu:// after the upload_dir
+        // filter is removed — pclzip then receives an iu:// path with the stream
+        // wrapper already unregistered, causing "archive incompatible" errors.
+        $admin = InfiniteUploadsAdmin::get_instance();
+        remove_filter( 'wp_handle_upload', [ $admin, 'handle_upload' ], 10 );
+        remove_filter( 'pre_move_uploaded_file', [ $admin, 'set_the_new_file_path' ], 10 );
+
         // Unregister the iu:// stream wrapper so plugin/theme ZIPs are never routed through cloud storage.
         if ( in_array( 'iu', stream_get_wrappers(), true ) ) {
             stream_wrapper_unregister( 'iu' );

--- a/inc/InfiniteUploadsAdmin.php
+++ b/inc/InfiniteUploadsAdmin.php
@@ -2429,7 +2429,9 @@ class InfiniteUploadsAdmin {
 
         $tree = $this->prepare_directory_tree( $scan_dir, $excluded_files, $virtual_paths, $upload_dir );
 
-        wp_send_json_success( $tree );
+        // jstree's core.data AJAX loader expects a raw JSON array — not WordPress's
+        // {"success":true,"data":[...]} envelope — so use wp_send_json() directly.
+        wp_send_json( $tree );
 
     }
 

--- a/inc/InfiniteUploadsRewriter.php
+++ b/inc/InfiniteUploadsRewriter.php
@@ -12,6 +12,7 @@ class InfiniteUploadsRewriter {
 	protected $replacements = [];    // urls to be searched for and replaced with CDN URL
 	protected $cdn_url = null;    // CDN URL
 	protected $exclusions = [];
+	protected $smush_url_fix_pairs = [];    // bad smush next-gen URL => correct URL
 
 	/**
 	 * constructor
@@ -46,6 +47,27 @@ class InfiniteUploadsRewriter {
 
 		// Make sure we replace urls in REST API responses
 		add_filter( 'the_content', [ &$this, 'rewrite_the_content' ], 100 );
+
+		// Build Smush Pro next-gen URL correction pairs.
+		// Smush derives its WebP/AVIF base URL via dirname(wp_upload_dir()['baseurl']), which
+		// strips the last path segment (site_id) from the CDN URL. We fix the resulting bad
+		// CDN URLs in HTML output.
+		// e.g. https://cdn.example.com/user_id/smush-webp/ → https://cdn.example.com/user_id/site_id/smush-webp/
+		$cdn_no_slash = rtrim( $this->cdn_url, '/' );
+		$last_slash   = strrpos( $cdn_no_slash, '/' );
+		if ( $last_slash !== false ) {
+			$parent_base = substr( $cdn_no_slash, 0, $last_slash );
+			// Guard: parent must still be a full URL (not just "https:").
+			if ( strpos( $parent_base, '://' ) !== false ) {
+				foreach ( [ 'smush-webp', 'smush-avif' ] as $next_gen_dir ) {
+					$bad  = $parent_base . '/' . $next_gen_dir . '/';
+					$good = $this->cdn_url . $next_gen_dir . '/'; // cdn_url already has trailing slash
+					if ( $bad !== $good ) {
+						$this->smush_url_fix_pairs[ $bad ] = $good;
+					}
+				}
+			}
+		}
 	}
 
 	/**
@@ -106,6 +128,13 @@ class InfiniteUploadsRewriter {
 
 		// call the cdn rewriter callback
 		$cdn_html = preg_replace_callback( $regex_rule, [ $this, 'rewrite_url' ], $html );
+
+		// Fix Smush next-gen (WebP/AVIF) URLs where dirname() stripped the site_id from the CDN path.
+		foreach ( $this->smush_url_fix_pairs as $bad_url => $good_url ) {
+			if ( strpos( $cdn_html, $bad_url ) !== false ) {
+				$cdn_html = str_replace( $bad_url, $good_url, $cdn_html );
+			}
+		}
 
 		return $cdn_html;
 	}

--- a/inc/InfiniteUploadsStreamWrapper.php
+++ b/inc/InfiniteUploadsStreamWrapper.php
@@ -138,14 +138,10 @@ class InfiniteUploadsStreamWrapper {
 	 * Replace your existing stream_open method with this version
 	 */
 	public function stream_open( $path, $mode, $options, &$opened_path ) {
-		error_log( '[stream_open] Checking for Path: ' . $path );
 		$path = $this->normalizeSmushPath( $path );
-		error_log( '[stream_open] Normalised Path: ' . $path );
 
 		$validation_result = $this->validateStreamPath( $path, $options );
 		if ( $validation_result !== true ) {
-			error_log( '[stream_open] REJECTED: ' . $validation_result );
-
 			return false;
 		}
 

--- a/infinite-uploads.php
+++ b/infinite-uploads.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Infinite Uploads
  * Description: Infinitely scalable cloud storage and delivery for your videos and uploads made easy! Upload directly to cloud storage and manage your files right from the WordPress Media Library.
- * Version: 3.2.0
+ * Version: 3.2.1
  * Author: Infinite Uploads
  * Author URI: https://infiniteuploads.com/?utm_source=iup_plugin&utm_medium=plugin&utm_campaign=iup_plugin&utm_content=meta
  * Text Domain: infinite-uploads
@@ -18,7 +18,7 @@
  * Copyright 2021-2025 ClikIT, LLC
 */
 
-define( 'INFINITE_UPLOADS_VERSION', '3.2.0' );
+define( 'INFINITE_UPLOADS_VERSION', '3.2.1' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
     require_once __DIR__ . '/vendor/autoload.php';

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 3.2.0
+Stable tag: 3.2.1
 Requires PHP: 8.0
 Contributors: bww
 Tags: cloud storage, offload media, offload, video streaming, cdn
@@ -211,48 +211,19 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Upgrade Notice ==
 
-3.2.0
-----------------------------------------------------------------------
+3.2.1
+-------------
 
-* **What's New**
-    * This release adds full folder management, improved filtering, and enhanced search to the WordPress Media Library, included with all paid Infinite Uploads subscriptions.
-
-* **Core Folder Management**
-    * Unlimited nested folder creation in the WordPress Media Library
-    * Drag-and-drop to move files into folders, including bulk selection
-    * Direct upload into a specific folder, including full folder structures from your computer
-    * Rename folders inline
-    * Color-code folders for visual distinction
-    * Bulk folder actions: select multiple folders, then move or delete in one step
-    * Files in deleted folders automatically move to Uncategorized
-    * Auto-enables on active paid plans (toggle to disable in settings)
-    * Full revert to standard WordPress behavior when disabled
-    * Resizable folder sidebar
-
-* **Sorting and Enhanced Search**
-    * Sort files by name, title, author, date added, date modified, size, and file type
-    * Sort folders by name, date created, date modified, and folder size
-    * Search files and folders by name in the Media Library grid and modal
-
-* **Page Builder Compatibility**
-    * Folders appear in the media picker across all major page builders and plugins:
-        * Elementor
-        * Divi
-        * Bricks
-        * Gutenberg / FSE
-        * Beaver Builder
-        * Oxygen
-        * Brizy
-        * WooCommerce product galleries
-
-* **Notes**
-    * Folder data is stored in a custom table. Core WP tables are not modified.
-    * Folder actions respect user roles: admins manage all, editors manage their own.
-    * Disabling Media Library features in settings will flatten folders to Uncategorized with a confirmation prompt if folders are in use.
-    * Folders are removed in an unlicensed state, but no media files are deleted.
-    * Enabled by default on all sites with Infinite Uploads, disabling is possible via Infinite Uploads settings.
+* Fixed an issue where the exclusion file tree was not showing.
+* Fixed a bug causing Infinite Uploads to corrupt plugin ZIP installations from the WordPress admin.
 
 == Changelog ==
+
+3.2.1
+----------------------------------------------------------------------
+
+* Fixed an issue where the exclusion file tree was not showing.
+* Fixed a bug causing Infinite Uploads to corrupt plugin ZIP installations from the WordPress admin.
 
 3.2.0
 ----------------------------------------------------------------------


### PR DESCRIPTION
* Fixed an issue where the exclusion file tree was not showing.
* Fixed a bug causing Infinite Uploads to corrupt plugin ZIP installations from the WordPress admin.
