### PR TITLE
EWWW, Imagify, Smush PRO, Shortpixel Integration Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,16 +60,24 @@ jobs:
       # ----------------------------------------
       # 5. Prepare Clean Plugin Directory
       # ----------------------------------------
+      # Do NOT create our own zip here. GitHub's upload-artifact action always
+      # wraps the artifact contents in a zip when users download from the UI;
+      # if we upload a zip file as the artifact, downloaders get a zip-inside-a-zip
+      # (which WP's "Upload Plugin" rejects with "No valid plugins were found").
+      # Instead we prepare a staging directory whose contents GitHub will zip —
+      # that artifact zip becomes the WP-installable plugin package directly.
       - name: Prepare plugin package
         run: |
-          WORKDIR="$RUNNER_TEMP/${{ env.PLUGIN_SLUG }}"
-          rm -rf "$WORKDIR"
+          STAGE="${{ github.workspace }}/_iu_artifact"
+          WORKDIR="$STAGE/${{ env.PLUGIN_SLUG }}"
+          rm -rf "$STAGE"
           mkdir -p "$WORKDIR"
 
-          cp -a . "$WORKDIR/"
+          # Copy source into the slug directory (exclude the staging dir itself).
+          find . -mindepth 1 -maxdepth 1 ! -name "_iu_artifact" -exec cp -a {} "$WORKDIR/" \;
           cd "$WORKDIR"
 
-          # Remove development-only files
+          # Remove development-only files.
           find . -type d -name "node_modules" -exec rm -rf {} +
           find . -type d -name ".claude" -exec rm -rf {} +
           find . -type d -name ".github" -exec rm -rf {} +
@@ -90,22 +98,17 @@ jobs:
           find . -type d \( -name "tests" -o -name "bin" \) -exec rm -rf {} +
           find . -mindepth 1 -name ".*" -exec rm -rf {} +
 
-          # Create versioned zip. WordPress's "Upload Plugin" installer requires the
-          # plugin to live inside a single top-level directory in the archive; zipping
-          # the workdir's contents flat produces "No valid plugins were found". Change
-          # to the parent and zip the slug-named directory itself so the archive layout
-          # is: <zip>/<slug>/<plugin files>.
-          cd "$RUNNER_TEMP"
-          zip -r "$RUNNER_TEMP/${{ steps.vars.outputs.zip_name }}.zip" "${{ env.PLUGIN_SLUG }}"
-
       # ----------------------------------------
       # 6. Upload Artifact
       # ----------------------------------------
+      # Upload the STAGING DIRECTORY so GitHub's artifact packaging produces a zip
+      # whose top-level entry is the slug-named plugin folder. Downloaded zip is
+      # WP-installable as-is — no double wrapping.
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.vars.outputs.zip_name }}
-          path: ${{ runner.temp }}/${{ steps.vars.outputs.zip_name }}.zip
+          path: ${{ github.workspace }}/_iu_artifact/
           retention-days: 3
 
       # ----------------------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  PLUGIN_SLUG: infnite-uploads
+  PLUGIN_SLUG: infinite-uploads
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           WORKDIR="$RUNNER_TEMP/${{ env.PLUGIN_SLUG }}"
           rm -rf "$WORKDIR"
           mkdir -p "$WORKDIR"
-          
+
           cp -a . "$WORKDIR/"
           cd "$WORKDIR"
 
@@ -90,8 +90,13 @@ jobs:
           find . -type d \( -name "tests" -o -name "bin" \) -exec rm -rf {} +
           find . -mindepth 1 -name ".*" -exec rm -rf {} +
 
-          # Create versioned zip file
-          zip -r "$RUNNER_TEMP/${{ steps.vars.outputs.zip_name }}.zip" .
+          # Create versioned zip. WordPress's "Upload Plugin" installer requires the
+          # plugin to live inside a single top-level directory in the archive; zipping
+          # the workdir's contents flat produces "No valid plugins were found". Change
+          # to the parent and zip the slug-named directory itself so the archive layout
+          # is: <zip>/<slug>/<plugin files>.
+          cd "$RUNNER_TEMP"
+          zip -r "$RUNNER_TEMP/${{ steps.vars.outputs.zip_name }}.zip" "${{ env.PLUGIN_SLUG }}"
 
       # ----------------------------------------
       # 6. Upload Artifact

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1304,6 +1304,53 @@ class InfiniteUploads {
     }
 
     /**
+     * When file exclusion is enabled, convert CDN URLs for excluded paths to local server URLs.
+     * If the local file doesn't yet exist (was written to cloud before exclusion was configured),
+     * it is copied from the cloud stream to local disk on first access.
+     *
+     * Hooked to `style_loader_src` and `script_loader_src`.
+     *
+     * @param  string  $src  Asset URL as registered with wp_enqueue_style/script.
+     * @return string
+     */
+    public function filter_excluded_asset_src( $src ) {
+        if ( ! InfiniteUploadsHelper::is_file_exclusion_enabled() ) {
+            return $src;
+        }
+
+        // Strip query string (?ver=...) before path/file comparisons; restore later.
+        $query     = '';
+        $clean_src = $src;
+        if ( false !== strpos( $src, '?' ) ) {
+            [ $clean_src, $query ] = explode( '?', $src, 2 );
+            $query = '?' . $query;
+        }
+
+        // Normalize to https before comparison — the cloud URL is always https
+        // but WordPress may enqueue assets with http:// (non-SSL or mixed-content).
+        $normalized = set_url_scheme( $clean_src, 'https' );
+        $local_url  = InfiniteUploadsHelper::get_valid_file_url( $normalized, true );
+
+        if ( $local_url === $normalized ) {
+            return $src;
+        }
+
+        // The URL was converted to local — ensure the file exists on disk.
+        $local_path = InfiniteUploadsHelper::get_local_path_from_url( $local_url );
+        if ( ! file_exists( $local_path ) ) {
+            $cloud_path = InfiniteUploadsHelper::get_cloud_file_path( $local_path );
+            if ( $cloud_path !== $local_path ) {
+                if ( ! is_dir( dirname( $local_path ) ) ) {
+                    wp_mkdir_p( dirname( $local_path ) );
+                }
+                @copy( $cloud_path, $local_path );
+            }
+        }
+
+        return file_exists( $local_path ) ? $local_url . $query : $src;
+    }
+
+    /**
      * Get the iu:// basedir (e.g. "iu://bucket-name/path/to/uploads").
      *
      * @return string|false
@@ -1336,6 +1383,10 @@ class InfiniteUploads {
         // EWWW Image Optimizer: provide local copies of iu:// files for optimization.
         add_filter( 'ewww_image_optimizer_remote_fetched', [ $this, 'ewww_remote_fetch' ], 10, 3 );
         add_action( 'ewww_image_optimizer_after_optimize_attachment', [ $this, 'ewww_remote_push' ], 10, 2 );
+
+        // Elementor and other plugins that write CSS/JS to iu:// basedir: serve from local URL.
+        add_filter( 'style_loader_src', [ $this, 'filter_excluded_asset_src' ] );
+        add_filter( 'script_loader_src', [ $this, 'filter_excluded_asset_src' ] );
 
         // Imagify: support offloaded media and next-gen picture-tag delivery on IU CDN.
         if ( interface_exists( '\Imagify\CDN\PushCDNInterface' ) ) {

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1591,6 +1591,73 @@ class InfiniteUploads {
     }
 
     /**
+     * ShortPixel compatibility: redirect the backup directory to local disk.
+     *
+     * ShortPixel computes its backup base from `wp_get_upload_dir()['basedir']`, which
+     * IU has filtered to `iu://bucket`. ShortPixel then tries to create the backup
+     * directory and copy the original file there before optimizing — but on stream
+     * wrappers, mkdir/chmod/is_writable behave differently than ShortPixel's
+     * DirectoryModel::check() expects, so the backup write fails with the user-facing
+     * "Could not create backup. Please check file permissions" message.
+     *
+     * Strategy: build the same `<base>/ShortpixelBackups/<relative_path>` structure
+     * but rooted at the *original local* uploads basedir, not the iu:// override.
+     * `/ShortpixelBackups/` is already added to `infinite_uploads_sync_exclusions`
+     * via `compatibility_exclusions()`, so these backups stay local and never get
+     * pushed to cloud.
+     *
+     * Hooked to `shortpixel/file/backup_folder`.
+     *
+     * @param  mixed  $directory  ShortPixel DirectoryModel for the computed backup folder.
+     * @param  mixed  $file       ShortPixel FileModel for the source image.
+     *
+     * @return mixed  Replacement DirectoryModel pointing at a local-disk backup folder,
+     *                or the original $directory if we can't safely override.
+     */
+    public function shortpixel_backup_folder( $directory, $file ) {
+        if ( ! function_exists( 'wpSPIO' ) || ! is_object( $directory ) || ! method_exists( $directory, 'getPath' ) ) {
+            return $directory;
+        }
+
+        $current_path = (string) $directory->getPath();
+        $marker       = 'ShortpixelBackups';
+
+        $idx = strrpos( $current_path, $marker );
+        if ( $idx === false ) {
+            return $directory;
+        }
+
+        // Everything after `ShortpixelBackups/` — preserves ShortPixel's own subdir layout.
+        $relative_subdir = ltrim( substr( $current_path, $idx + strlen( $marker ) ), '/' . DIRECTORY_SEPARATOR );
+
+        $local_uploads_root = $this->get_original_upload_dir_root();
+        if ( empty( $local_uploads_root['basedir'] ) ) {
+            return $directory;
+        }
+
+        $local_backup_path = trailingslashit( $local_uploads_root['basedir'] )
+                             . $marker
+                             . ( $relative_subdir !== '' ? '/' . $relative_subdir : '/' );
+
+        // Already pointing at the same local target — nothing to do (don't recurse).
+        if ( $current_path === $local_backup_path ) {
+            return $directory;
+        }
+
+        try {
+            $fs        = wpSPIO()->filesystem();
+            $local_dir = $fs->getDirectory( $local_backup_path );
+            if ( method_exists( $local_dir, 'check' ) && $local_dir->check( true ) ) {
+                return $local_dir;
+            }
+        } catch ( \Throwable $e ) {
+            // Fall through to original directory on any unexpected ShortPixel error.
+        }
+
+        return $directory;
+    }
+
+    /**
      * When file exclusion is enabled, convert CDN URLs for excluded paths to local server URLs.
      * If the local file doesn't yet exist (was written to cloud before exclusion was configured),
      * it is copied from the cloud stream to local disk on first access.
@@ -1706,6 +1773,15 @@ class InfiniteUploads {
         // error into a useful IU-aware status read from wp_ewwwio_images.
         add_action( 'manage_media_custom_column', [ $this, 'ewww_column_buffer_start' ], 9, 2 );
         add_action( 'manage_media_custom_column', [ $this, 'ewww_column_buffer_end' ], 11, 2 );
+
+        // ShortPixel: redirect backup folder to local disk. ShortPixel computes its backup
+        // base as wp_get_upload_dir()['basedir'] . '/ShortpixelBackups', which IU has
+        // filtered to iu://bucket — directory creation and copy fail under stream wrappers
+        // (the mkdir/chmod/is_writable semantics on iu:// paths don't satisfy ShortPixel's
+        // pre-flight check). Override the backup directory to the original local uploads
+        // path; /ShortpixelBackups/ is already in IU's sync exclusions, so backups stay
+        // local and never get pushed to cloud.
+        add_filter( 'shortpixel/file/backup_folder', [ $this, 'shortpixel_backup_folder' ], 10, 2 );
 
         // Elementor and other plugins that write CSS/JS to iu:// basedir: serve from local URL.
         add_filter( 'style_loader_src', [ $this, 'filter_excluded_asset_src' ] );

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1449,6 +1449,148 @@ class InfiniteUploads {
     }
 
     /**
+     * Tracks whether we opened an output buffer for the current Media Library column
+     * render. Keyed by attachment ID so concurrent column callbacks don't interfere.
+     *
+     * @var array<int, true>
+     */
+    private $ewww_column_buffered = [];
+
+    /**
+     * Start an output buffer around EWWW's column callback for iu://-hosted attachments,
+     * so we can rewrite EWWW's "Could not retrieve file path" failure into a useful
+     * IU-aware status. Hooked to `manage_media_custom_column` at priority 9.
+     *
+     * @param  string  $column_name
+     * @param  int     $id
+     */
+    public function ewww_column_buffer_start( $column_name, $id ) {
+        if ( 'ewww-image-optimizer' !== $column_name ) {
+            return;
+        }
+        $file = get_attached_file( (int) $id );
+        if ( ! $file || strpos( $file, 'iu://' ) !== 0 ) {
+            return;
+        }
+        ob_start();
+        $this->ewww_column_buffered[ (int) $id ] = true;
+    }
+
+    /**
+     * Close the output buffer opened by ewww_column_buffer_start(). If EWWW emitted
+     * its "Could not retrieve file path" failure (because ewwwio_is_file() rejects
+     * iu:// paths), replace it with a status block that reports IU-cloud storage
+     * plus the EWWW optimization stats from `wp_ewwwio_images`. Otherwise pass
+     * EWWW's normal output through unchanged.
+     *
+     * Hooked to `manage_media_custom_column` at priority 11.
+     *
+     * @param  string  $column_name
+     * @param  int     $id
+     */
+    public function ewww_column_buffer_end( $column_name, $id ) {
+        if ( 'ewww-image-optimizer' !== $column_name ) {
+            return;
+        }
+        $id = (int) $id;
+        if ( empty( $this->ewww_column_buffered[ $id ] ) ) {
+            return;
+        }
+        unset( $this->ewww_column_buffered[ $id ] );
+
+        $output = ob_get_clean();
+
+        if ( strpos( $output, 'Could not retrieve file path' ) === false ) {
+            // EWWW rendered something useful — let it stand.
+            echo $output; // phpcs:ignore WordPress.Security.EscapeOutput
+            return;
+        }
+
+        // Replace the error with IU-aware status. Same wrapper EWWW uses so its
+        // CSS / JS hooks (the per-row spinner, debug button) keep working.
+        $stats = $this->ewww_attachment_stats( $id );
+
+        $html  = '<div id="ewww-media-status-' . $id . '" class="ewww-media-status" data-id="' . $id . '">';
+        $html .= '<div>' . esc_html__( 'Infinite Uploads (cloud-stored)', 'infinite-uploads' ) . '</div>';
+
+        if ( $stats['rows'] > 0 ) {
+            $saved = max( 0, (int) $stats['orig'] - (int) $stats['opt'] );
+            $pct   = $stats['orig'] > 0 ? round( ( $saved / $stats['orig'] ) * 100, 1 ) : 0;
+            $html .= '<div>' . sprintf(
+                /* translators: 1: number of image sizes, 2: humanized bytes, 3: percentage */
+                esc_html__( 'Optimized %1$d sizes — saved %2$s (%3$s%%)', 'infinite-uploads' ),
+                (int) $stats['rows'],
+                esc_html( size_format( $saved ) ),
+                esc_html( (string) $pct )
+            ) . '</div>';
+
+            if ( $stats['webp_rows'] > 0 ) {
+                $html .= '<div>' . sprintf(
+                    /* translators: %d: number of WebP sidecars */
+                    esc_html__( 'WebP: %d files', 'infinite-uploads' ),
+                    (int) $stats['webp_rows']
+                ) . '</div>';
+            }
+        } else {
+            $html .= '<div>' . esc_html__( 'Not yet optimized.', 'infinite-uploads' ) . '</div>';
+        }
+
+        $html .= '</div>';
+
+        echo $html; // phpcs:ignore WordPress.Security.EscapeOutput
+    }
+
+    /**
+     * Aggregate optimization stats for an attachment from `wp_ewwwio_images`.
+     *
+     * @param  int  $id
+     *
+     * @return array{rows:int, orig:int, opt:int, webp_rows:int}
+     */
+    private function ewww_attachment_stats( $id ) {
+        global $wpdb;
+        static $cache = [];
+
+        if ( isset( $cache[ $id ] ) ) {
+            return $cache[ $id ];
+        }
+
+        $defaults = [ 'rows' => 0, 'orig' => 0, 'opt' => 0, 'webp_rows' => 0 ];
+        $table    = $wpdb->prefix . 'ewwwio_images';
+
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
+            $cache[ $id ] = $defaults;
+
+            return $defaults;
+        }
+
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT
+                    COUNT(*) AS rows_count,
+                    COALESCE(SUM(orig_size), 0) AS orig,
+                    COALESCE(SUM(image_size), 0) AS opt,
+                    SUM(CASE WHEN webp_size > 0 AND webp_error = 0 THEN 1 ELSE 0 END) AS webp_rows
+                FROM {$table}
+                WHERE attachment_id = %d",
+                $id
+            ),
+            ARRAY_A
+        );
+
+        $stats = $row ? [
+            'rows'      => (int) $row['rows_count'],
+            'orig'      => (int) $row['orig'],
+            'opt'       => (int) $row['opt'],
+            'webp_rows' => (int) $row['webp_rows'],
+        ] : $defaults;
+
+        $cache[ $id ] = $stats;
+
+        return $stats;
+    }
+
+    /**
      * When file exclusion is enabled, convert CDN URLs for excluded paths to local server URLs.
      * If the local file doesn't yet exist (was written to cloud before exclusion was configured),
      * it is copied from the cloud stream to local disk on first access.
@@ -1555,6 +1697,15 @@ class InfiniteUploads {
         // tag — including ones EWWW never converted, which would 404 on fetch. Opt out
         // per-image by consulting wp_ewwwio_images.
         add_filter( 'ewww_image_optimizer_skip_webp_rewrite', [ $this, 'ewww_skip_webp_rewrite' ], 10, 2 );
+
+        // EWWW's Media Library "Image Optimizer" column emits "Could not retrieve file
+        // path" for iu://-hosted attachments because its hard-coded CDN recognition
+        // (Amazon_S3_And_CloudFront / S3_Uploads / WP Stateless / Azure) doesn't include
+        // Infinite Uploads, and ewwwio_is_file() rejects any path containing '://'. We
+        // wrap EWWW's column callback in an output buffer and rewrite that specific
+        // error into a useful IU-aware status read from wp_ewwwio_images.
+        add_action( 'manage_media_custom_column', [ $this, 'ewww_column_buffer_start' ], 9, 2 );
+        add_action( 'manage_media_custom_column', [ $this, 'ewww_column_buffer_end' ], 11, 2 );
 
         // Elementor and other plugins that write CSS/JS to iu:// basedir: serve from local URL.
         add_filter( 'style_loader_src', [ $this, 'filter_excluded_asset_src' ] );

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1591,6 +1591,81 @@ class InfiniteUploads {
     }
 
     /**
+     * ShortPixel compatibility: tell ShortPixel that iu:// paths are valid stateless
+     * remote files (via PHP stream wrapper). ShortPixel's `pathIsUrl()` flags every
+     * string containing `://` as a URL and routes the FileModel through `UrlToPath()`,
+     * which leaves `exists`/`is_readable`/`is_file` all false unless this filter claims
+     * the URL. Returning the integer VIRTUAL_STATELESS value (2) — same constant
+     * ShortPixel uses internally — sets exists=true, is_readable=true, is_file=true,
+     * is_writable=true, and lets ShortPixel proceed to the actual read/copy/optimize
+     * operations, all of which work transparently against iu:// via the stream wrapper.
+     *
+     * Hooked to `shortpixel/image/urltopath`.
+     *
+     * @param  mixed   $result   Current handler result. False if no handler claimed it.
+     * @param  string  $url      The URL/path being resolved.
+     * @param  string  $rawpath  The original raw path (pre-stripping).
+     *
+     * @return mixed
+     */
+    public function shortpixel_urltopath( $result, $url, $rawpath ) {
+        if ( $result !== false ) {
+            return $result; // another handler already claimed it
+        }
+        if ( strpos( (string) $url, 'iu://' ) === 0 || strpos( (string) $rawpath, 'iu://' ) === 0 ) {
+            // VIRTUAL_STATELESS = 2 (FileModel::$VIRTUAL_STATELESS).
+            return 2;
+        }
+
+        return $result;
+    }
+
+    /**
+     * ShortPixel compatibility: populate FileModel::$filesize for iu:// virtual files,
+     * so getFileSize() returns the real size instead of the -1 sentinel that virtual
+     * files normally yield. Without this, FileModel::copy() bails at the
+     * `getFileSize() <= 0` guard for any iu:// source — even though the file exists
+     * and PHP's copy() can read it via the stream wrapper.
+     *
+     * Hooked to `shortpixel/file/exists` (which is the only filter giving us the
+     * FileModel instance early enough). Uses reflection because $filesize is
+     * protected; populates once per FileModel and short-circuits on subsequent calls.
+     *
+     * @param  bool    $exists    Current exists value.
+     * @param  string  $fullpath  Full file path.
+     * @param  mixed   $file      ShortPixel FileModel.
+     *
+     * @return bool
+     */
+    public function shortpixel_prefill_filesize( $exists, $fullpath, $file ) {
+        if ( ! is_object( $file ) || strpos( (string) $fullpath, 'iu://' ) !== 0 ) {
+            return $exists;
+        }
+
+        try {
+            $reflection = new \ReflectionObject( $file );
+            if ( ! $reflection->hasProperty( 'filesize' ) ) {
+                return $exists;
+            }
+
+            $prop = $reflection->getProperty( 'filesize' );
+            $prop->setAccessible( true );
+            if ( $prop->getValue( $file ) !== null ) {
+                return $exists; // already populated this request
+            }
+
+            $size = @filesize( $fullpath ); // hits stream wrapper, cached per-request
+            if ( $size !== false && $size > 0 ) {
+                $prop->setValue( $file, (int) $size );
+            }
+        } catch ( \Throwable $e ) {
+            // Reflection or stat failure — leave the FileModel as-is.
+        }
+
+        return $exists;
+    }
+
+    /**
      * ShortPixel compatibility: redirect the backup directory to local disk.
      *
      * ShortPixel computes its backup base from `wp_get_upload_dir()['basedir']`, which
@@ -1773,6 +1848,27 @@ class InfiniteUploads {
         // error into a useful IU-aware status read from wp_ewwwio_images.
         add_action( 'manage_media_custom_column', [ $this, 'ewww_column_buffer_start' ], 9, 2 );
         add_action( 'manage_media_custom_column', [ $this, 'ewww_column_buffer_end' ], 11, 2 );
+
+        // ShortPixel: claim iu:// paths so ShortPixel's FileModel treats them as readable
+        // virtual files. ShortPixel's FileModel constructor calls pathIsUrl() — which
+        // returns true for ANY string containing "://" — and routes the file through
+        // UrlToPath(). Without an `shortpixel/image/urltopath` handler returning truthy,
+        // ShortPixel sets exists=false, is_readable=false, is_file=false, and every
+        // subsequent file op (copy(), getFileSize(), createBackup()) bails out early.
+        // Returning VIRTUAL_STATELESS marks the file as a stream-wrapper-backed remote
+        // that *is* writable — ShortPixel will then attempt the actual operations,
+        // which work because PHP's copy()/file_exists()/filesize() handle iu:// via
+        // the stream wrapper.
+        add_filter( 'shortpixel/image/urltopath', [ $this, 'shortpixel_urltopath' ], 10, 3 );
+
+        // ShortPixel: populate FileModel::$filesize from the iu:// stream so virtual files
+        // don't bail in copy() and other size-aware checks. ShortPixel's getFileSize()
+        // returns -1 for any virtual file; copy() then rejects the source ("Source file
+        // in copy has a filesize of zero"). There's no `getFileSize` filter, but the
+        // `shortpixel/file/exists` filter receives the FileModel instance — we use
+        // reflection to set `$filesize` once (cheap once-per-request HEAD via the stream
+        // wrapper's own stat cache), so getFileSize()'s first branch returns it directly.
+        add_filter( 'shortpixel/file/exists', [ $this, 'shortpixel_prefill_filesize' ], 10, 3 );
 
         // ShortPixel: redirect backup folder to local disk. ShortPixel computes its backup
         // base as wp_get_upload_dir()['basedir'] . '/ShortpixelBackups', which IU has

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1318,6 +1318,17 @@ class InfiniteUploads {
             return $src;
         }
 
+        // Bail early if the URL is not under the uploads directory or the IU CDN.
+        // Without this, every enqueued theme/plugin/core asset on the page runs
+        // through the exclusion checks below.
+        $local_uploads_url = InfiniteUploadsHelper::get_local_upload_url();
+        $cloud_uploads_url = InfiniteUploadsHelper::get_cloud_upload_url();
+        if ( stripos( $src, $local_uploads_url ) === false
+             && stripos( $src, $cloud_uploads_url ) === false
+        ) {
+            return $src;
+        }
+
         // Strip query string (?ver=...) before path/file comparisons; restore later.
         $query     = '';
         $clean_src = $src;

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1286,11 +1286,39 @@ class InfiniteUploads {
             $exclusions[] = '/blog-avatars/';
             $exclusions[] = '/buddypress/';
         }
+
         $exclusions[] = '/bb-plugin/';
+        $exclusions[] = '/ShortpixelBackups/';
 
         return $exclusions;
     }
 }
+
+/**
+ * Check if a file is already offloaded to S3.
+ *
+ * @param string $url The URL of the file to check.
+ *
+ * @return bool True if the file is offloaded, false otherwise.
+ */
+function infinite_uploads_check_offloaded( $url ) {
+    global $wpdb;
+    $parsed = wp_parse_url( $url );
+
+    if ( isset( $parsed['path'] ) ) {
+        // Check if the file is already offloaded to S3.
+        $total     = $wpdb->get_row( "SELECT * FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE file LIKE '%{$parsed['path']}%'" );
+        if($total && isset( $total->synced ) && $total->synced == 1 ) {
+            return true;
+        } else {
+            return false;
+
+        }
+    } else {
+        return false;
+    }
+}
+
 
 /**
  * Fix to not sync the WooCommerce Error Log Directory.

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1193,6 +1193,125 @@ class InfiniteUploads {
     }
 
     /**
+     * EWWW Image Optimizer compatibility: copy iu:// files to a local temp path so EWWW
+     * can optimize them. Hooked to `ewww_image_optimizer_remote_fetched`.
+     *
+     * @param  string|false  $filename  Local path resolved so far (false when not yet found).
+     * @param  int           $id        Attachment post ID.
+     * @param  array         $meta      Attachment metadata.
+     *
+     * @return string|false  Local path to the full-size image, or original $filename on failure.
+     */
+    public function ewww_remote_fetch( $filename, $id, $meta ) {
+        $iu_path = get_attached_file( $id );
+        if ( ! $iu_path || strpos( $iu_path, 'iu://' ) !== 0 ) {
+            return $filename;
+        }
+
+        $root_dirs  = $this->get_original_upload_dir_root();
+        $iu_basedir = $this->get_s3_basedir();
+        if ( ! $iu_basedir ) {
+            return $filename;
+        }
+
+        // Map iu:// path → local path.
+        $local_path = str_replace( $iu_basedir, $root_dirs['basedir'], $iu_path );
+        if ( $local_path === $iu_path ) {
+            return $filename;
+        }
+
+        if ( ! is_dir( dirname( $local_path ) ) ) {
+            wp_mkdir_p( dirname( $local_path ) );
+        }
+
+        // Copy full-size image to local.
+        if ( ! file_exists( $local_path ) ) {
+            copy( $iu_path, $local_path );
+        }
+
+        // Copy resized versions to local so EWWW can optimize them too.
+        if ( isset( $meta['sizes'] ) && is_array( $meta['sizes'] ) ) {
+            $base_iu    = trailingslashit( dirname( $iu_path ) );
+            $base_local = trailingslashit( dirname( $local_path ) );
+            foreach ( $meta['sizes'] as $size => $data ) {
+                if ( empty( $data['file'] ) ) {
+                    continue;
+                }
+                $iu_resize    = $base_iu . wp_basename( $data['file'] );
+                $local_resize = $base_local . wp_basename( $data['file'] );
+                if ( ! file_exists( $local_resize ) ) {
+                    copy( $iu_resize, $local_resize );
+                }
+            }
+        }
+
+        return file_exists( $local_path ) ? $local_path : $filename;
+    }
+
+    /**
+     * EWWW Image Optimizer compatibility: push the locally-optimized files back to iu://
+     * and remove the local copies. Hooked to `ewww_image_optimizer_after_optimize_attachment`.
+     *
+     * @param  int    $id    Attachment post ID.
+     * @param  array  $meta  Attachment metadata.
+     */
+    public function ewww_remote_push( $id, $meta ) {
+        $iu_path = get_attached_file( $id );
+        if ( ! $iu_path || strpos( $iu_path, 'iu://' ) !== 0 ) {
+            return;
+        }
+
+        $root_dirs  = $this->get_original_upload_dir_root();
+        $iu_basedir = $this->get_s3_basedir();
+        if ( ! $iu_basedir ) {
+            return;
+        }
+
+        $local_path = str_replace( $iu_basedir, $root_dirs['basedir'], $iu_path );
+        if ( $local_path === $iu_path ) {
+            return;
+        }
+
+        // Push full-size back to iu://.
+        if ( file_exists( $local_path ) ) {
+            copy( $local_path, $iu_path );
+            unlink( $local_path );
+        }
+
+        // Push resized versions back to iu://.
+        if ( isset( $meta['sizes'] ) && is_array( $meta['sizes'] ) ) {
+            $base_iu    = trailingslashit( dirname( $iu_path ) );
+            $base_local = trailingslashit( dirname( $local_path ) );
+            foreach ( $meta['sizes'] as $size => $data ) {
+                if ( empty( $data['file'] ) ) {
+                    continue;
+                }
+                $local_resize = $base_local . wp_basename( $data['file'] );
+                $iu_resize    = $base_iu . wp_basename( $data['file'] );
+                if ( file_exists( $local_resize ) ) {
+                    copy( $local_resize, $iu_resize );
+                    unlink( $local_resize );
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the iu:// basedir (e.g. "iu://bucket-name/path/to/uploads").
+     *
+     * @return string|false
+     */
+    private function get_s3_basedir() {
+        $upload_dir = wp_upload_dir();
+        $basedir    = $upload_dir['basedir'];
+        if ( strpos( $basedir, 'iu://' ) !== 0 ) {
+            return false;
+        }
+
+        return untrailingslashit( $basedir );
+    }
+
+    /**
      * Handle compatibility for various third party plugins
      */
     function plugin_compatibility() {
@@ -1206,6 +1325,10 @@ class InfiniteUploads {
 
         // Smush Pro: redirect excluded file sizes to local paths.
         add_filter( 'wp_smush_media_item_size', [ $this, 'filter_smush_media_item_size' ], 10, 4 );
+
+        // EWWW Image Optimizer: provide local copies of iu:// files for optimization.
+        add_filter( 'ewww_image_optimizer_remote_fetched', [ $this, 'ewww_remote_fetch' ], 10, 3 );
+        add_action( 'ewww_image_optimizer_after_optimize_attachment', [ $this, 'ewww_remote_push' ], 10, 2 );
 
         //Handle WooCommerce CSV imports
         add_filter( 'woocommerce_product_csv_importer_check_import_file_path', '__return_false' );

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1266,6 +1266,12 @@ class InfiniteUploads {
      * EWWW Image Optimizer compatibility: push the locally-optimized files back to iu://
      * and remove the local copies. Hooked to `ewww_image_optimizer_after_optimize_attachment`.
      *
+     * Also pushes any WebP/AVIF sidecars EWWW generated next to each image
+     * (e.g. image.png.webp, image-150x150.png.webp). Without that, only the original
+     * .png/.jpg makes it back to cloud and the next-gen siblings stay on local disk —
+     * the CDN ends up serving the original format and EWWW's <picture>/JS rewrites
+     * 404 on the missing webp/avif URLs.
+     *
      * @param  int    $id    Attachment post ID.
      * @param  array  $meta  Attachment metadata.
      */
@@ -1286,13 +1292,10 @@ class InfiniteUploads {
             return;
         }
 
-        // Push full-size back to iu://.
-        if ( file_exists( $local_path ) ) {
-            copy( $local_path, $iu_path );
-            unlink( $local_path );
-        }
+        // Push full-size + its webp/avif sidecars back to iu://.
+        $this->ewww_push_file_with_sidecars( $local_path, $iu_path );
 
-        // Push resized versions back to iu://.
+        // Push resized versions + their webp/avif sidecars back to iu://.
         if ( isset( $meta['sizes'] ) && is_array( $meta['sizes'] ) ) {
             $base_iu    = trailingslashit( dirname( $iu_path ) );
             $base_local = trailingslashit( dirname( $local_path ) );
@@ -1302,9 +1305,31 @@ class InfiniteUploads {
                 }
                 $local_resize = $base_local . wp_basename( $data['file'] );
                 $iu_resize    = $base_iu . wp_basename( $data['file'] );
-                if ( file_exists( $local_resize ) ) {
-                    copy( $local_resize, $iu_resize );
-                    unlink( $local_resize );
+                $this->ewww_push_file_with_sidecars( $local_resize, $iu_resize );
+            }
+        }
+    }
+
+    /**
+     * Copy a single file from local → iu:// and unlink the local copy. Also handles
+     * the `.webp` and `.avif` sidecars EWWW writes next to each image.
+     *
+     * @param  string  $local_path  Local filesystem path of the source file.
+     * @param  string  $iu_path     Equivalent iu:// destination path.
+     */
+    private function ewww_push_file_with_sidecars( $local_path, $iu_path ) {
+        if ( file_exists( $local_path ) ) {
+            if ( @copy( $local_path, $iu_path ) ) {
+                @unlink( $local_path );
+            }
+        }
+
+        foreach ( [ '.webp', '.avif' ] as $ext ) {
+            $local_sidecar = $local_path . $ext;
+            $iu_sidecar    = $iu_path . $ext;
+            if ( file_exists( $local_sidecar ) ) {
+                if ( @copy( $local_sidecar, $iu_sidecar ) ) {
+                    @unlink( $local_sidecar );
                 }
             }
         }

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -593,6 +593,7 @@ class InfiniteUploads {
                         'svg',
                         'svgz',
                         'webp',
+                        'avif',
                 ],
                 'audio'    => [
                         'aac',
@@ -787,6 +788,12 @@ class InfiniteUploads {
         foreach ( $to_purge as $key => $file ) {
             $to_purge[ $key ] = str_replace( $dirs['basedir'], $dirs['baseurl'], $file );
         }
+
+        if ( interface_exists( '\Imagify\CDN\PushCDNInterface' ) ) {
+            $to_purge = array_merge( $to_purge, InfiniteUploadsImagify::get_attachment_nextgen_urls( $post_id ) );
+        }
+
+        $to_purge = array_values( array_unique( $to_purge ) );
 
         //purge these from CDN cache
         $this->api->purge( $to_purge );
@@ -1329,6 +1336,11 @@ class InfiniteUploads {
         // EWWW Image Optimizer: provide local copies of iu:// files for optimization.
         add_filter( 'ewww_image_optimizer_remote_fetched', [ $this, 'ewww_remote_fetch' ], 10, 3 );
         add_action( 'ewww_image_optimizer_after_optimize_attachment', [ $this, 'ewww_remote_push' ], 10, 2 );
+
+        // Imagify: support offloaded media and next-gen picture-tag delivery on IU CDN.
+        if ( interface_exists( '\Imagify\CDN\PushCDNInterface' ) ) {
+            InfiniteUploadsImagify::get_instance()->init();
+        }
 
         //Handle WooCommerce CSV imports
         add_filter( 'woocommerce_product_csv_importer_check_import_file_path', '__return_false' );

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -194,7 +194,7 @@ class InfiniteUploads {
 
         $this->plugin_compatibility();
 
-        if ( ( ! defined( 'INFINITE_UPLOADS_DISABLE_REPLACE_UPLOAD_URL' ) || ! INFINITE_UPLOADS_DISABLE_REPLACE_UPLOAD_URL ) && $api_data->site->cdn_enabled ) {
+        if ( ! defined( 'INFINITE_UPLOADS_DISABLE_REPLACE_UPLOAD_URL' ) || ! INFINITE_UPLOADS_DISABLE_REPLACE_UPLOAD_URL ) {
             //makes this work with pre 3.5 MU ms_files rewriting (ie domain.com/files/filename.jpg)
             $original_root_dirs = $this->get_original_upload_dir_root();
             $replacements       = [ $original_root_dirs['baseurl'] ];
@@ -210,6 +210,13 @@ class InfiniteUploads {
             } else {
                 $cdn_url = $this->get_s3_url();
             }
+            // Instantiate the rewriter regardless of $cdn_enabled. Reason: filter_upload_dir()
+            // unconditionally replaces wp_upload_dir()['baseurl'] with the CDN URL, which
+            // causes Smush to emit malformed next-gen URLs (https:/smush-webp/…) via its
+            // dirname(baseurl) derivation when the CDN URL is a host-only vanity domain.
+            // The rewriter's str_replace pass repairs those URLs — and it must run even
+            // when cdn_enabled is false, because Smush's output depends on the modified
+            // baseurl, not on whether the CDN is active.
             new InfiniteUploadsRewriter( $original_root_dirs['baseurl'], $replacements, $cdn_url );
         }
 

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1304,6 +1304,119 @@ class InfiniteUploads {
     }
 
     /**
+     * Add the IU CDN URL to EWWW's allowed-urls list. EWWW's Picture_Webp / JS_Webp
+     * rewriters only consider `<img>` elements whose URL matches one of these entries;
+     * without this, images served from the IU CDN are silently skipped.
+     *
+     * @param  array  $urls
+     *
+     * @return array
+     */
+    public function ewww_allowed_urls( $urls ) {
+        $cdn_url = $this->get_s3_url();
+        if ( $cdn_url ) {
+            $urls[] = trailingslashit( $cdn_url );
+        }
+
+        return $urls;
+    }
+
+    /**
+     * Add the IU CDN host to EWWW's allowed-domains list. Used in EWWW's cdn_to_local()
+     * translation, so URLs on our CDN resolve back to valid attachment paths.
+     *
+     * @param  array  $domains
+     *
+     * @return array
+     */
+    public function ewww_allowed_domains( $domains ) {
+        $cdn_url  = $this->get_s3_url();
+        $cdn_host = $cdn_url ? wp_parse_url( $cdn_url, PHP_URL_HOST ) : '';
+        if ( $cdn_host && ! in_array( $cdn_host, $domains, true ) ) {
+            $domains[] = $cdn_host;
+        }
+
+        return $domains;
+    }
+
+    /**
+     * Force EWWW's `webp_force` option on at runtime (DB value untouched) so its
+     * rewriter uses the allowed_urls match path for IU-hosted images. Required
+     * because EWWW's normal path calls is_file() on translated paths, which the
+     * IU stream wrapper's is_file() rejects for anything containing `://`.
+     *
+     * Hooked to `pre_option_ewww_image_optimizer_webp_force`.
+     *
+     * @return string
+     */
+    public function ewww_force_webp_at_runtime() {
+        return '1';
+    }
+
+    /**
+     * Opt out specific images from EWWW's WebP rewrite. With `webp_force` on (see
+     * ewww_force_webp_at_runtime) EWWW would wrap every IU-CDN image in a <picture>
+     * tag; for images EWWW never converted, the sibling `.webp` doesn't exist and
+     * the source would 404. Consult `wp_ewwwio_images` and skip anything not in it.
+     *
+     * Non-IU-CDN URLs defer to EWWW's default behavior (native AS3CF/S3 sites etc.).
+     *
+     * Hooked to `ewww_image_optimizer_skip_webp_rewrite`.
+     *
+     * @param  bool    $skip   Current skip decision from EWWW.
+     * @param  string  $image  The image URL being evaluated.
+     *
+     * @return bool
+     */
+    public function ewww_skip_webp_rewrite( $skip, $image ) {
+        // Respect an existing skip from another handler.
+        if ( $skip ) {
+            return $skip;
+        }
+
+        $cdn_url = $this->get_s3_url();
+        if ( ! $cdn_url || strpos( $image, $cdn_url ) === false ) {
+            // Not an IU CDN URL — let EWWW's normal logic decide.
+            return $skip;
+        }
+
+        // Strip query string and CDN prefix to get the upload-root-relative path.
+        $path = strtok( $image, '?' );
+        $path = str_replace( trailingslashit( $cdn_url ), '', $path );
+        if ( $path === '' ) {
+            return true;
+        }
+
+        return $this->ewww_has_converted_webp( wp_basename( $path ) ) ? false : true;
+    }
+
+    /**
+     * Check if EWWW has a successful WebP conversion on record for a given filename.
+     * Results are memoized for the request to avoid a query per `<img>` on the page.
+     *
+     * @param  string  $basename  File basename, e.g. "sitting-6@2x-285x300.png".
+     *
+     * @return bool
+     */
+    private function ewww_has_converted_webp( $basename ) {
+        global $wpdb;
+        static $converted = null;
+
+        if ( $converted === null ) {
+            $converted = [];
+            $table     = $wpdb->prefix . 'ewwwio_images';
+            if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) === $table ) {
+                $rows = $wpdb->get_col( "SELECT path FROM {$table} WHERE webp_size > 0 AND webp_error = 0" );
+                foreach ( (array) $rows as $row ) {
+                    $converted[ wp_basename( $row ) ] = true;
+                }
+            }
+        }
+
+        return isset( $converted[ $basename ] );
+    }
+
+    /**
      * When file exclusion is enabled, convert CDN URLs for excluded paths to local server URLs.
      * If the local file doesn't yet exist (was written to cloud before exclusion was configured),
      * it is copied from the cloud stream to local disk on first access.
@@ -1394,6 +1507,22 @@ class InfiniteUploads {
         // EWWW Image Optimizer: provide local copies of iu:// files for optimization.
         add_filter( 'ewww_image_optimizer_remote_fetched', [ $this, 'ewww_remote_fetch' ], 10, 3 );
         add_action( 'ewww_image_optimizer_after_optimize_attachment', [ $this, 'ewww_remote_push' ], 10, 2 );
+
+        // EWWW Image Optimizer: tell EWWW that the IU CDN hosts images so its
+        // Picture_Webp / JS_Webp rewriters actually consider our URLs.
+        add_filter( 'webp_allowed_urls', [ $this, 'ewww_allowed_urls' ] );
+        add_filter( 'webp_allowed_domains', [ $this, 'ewww_allowed_domains' ] );
+
+        // EWWW's non-forced rewrite path calls url_to_path_exists() → is_file() on the
+        // local disk, which fails for iu:// (the stream wrapper is rejected by is_file).
+        // Turn `webp_force` on at runtime so EWWW uses the allowed_urls match path
+        // instead of the local-disk check. Non-persistent: doesn't touch the DB option.
+        add_filter( 'pre_option_ewww_image_optimizer_webp_force', [ $this, 'ewww_force_webp_at_runtime' ] );
+
+        // With webp_force on, EWWW would blindly wrap every CDN image in a <picture>
+        // tag — including ones EWWW never converted, which would 404 on fetch. Opt out
+        // per-image by consulting wp_ewwwio_images.
+        add_filter( 'ewww_image_optimizer_skip_webp_rewrite', [ $this, 'ewww_skip_webp_rewrite' ], 10, 2 );
 
         // Elementor and other plugins that write CSS/JS to iu:// basedir: serve from local URL.
         add_filter( 'style_loader_src', [ $this, 'filter_excluded_asset_src' ] );

--- a/inc/InfiniteUploadsAdmin.php
+++ b/inc/InfiniteUploadsAdmin.php
@@ -118,68 +118,102 @@ class InfiniteUploadsAdmin {
     /**
      * Serve media URL based on file existence and sync status.
      *
-     * @param $url
+     * Resolution order:
+     *   1. If path is in the exclusion list, prefer the local URL (the user's intent).
+     *   2. For whichever URL-form we end up with, verify the file actually exists at
+     *      that location; if it doesn't, fall back to the other side (cloud ↔ local).
+     *   3. If neither side has the file, return the URL we started with so the
+     *      browser gets the natural 404 at the expected location.
      *
-     * @return array|mixed|string|string[]
+     * Cloud existence is verified via the stream wrapper's `file_exists('iu://...')`
+     * which reuses a HeadObject result cache within a request. That's authoritative —
+     * the old code relied on `wp_infinite_uploads_files.synced = 1`, but that table
+     * can be out-of-sync (missing rows for files written directly via the stream
+     * wrapper, rows marked `deleted = 1`, etc.), causing false 404s for files that
+     * are actually sitting on the CDN.
+     *
+     * @param string $url Attachment URL (local or cloud).
+     *
+     * @return string
      */
     public function serve_media_url( $url ) {
-        /**
-         * TODO: Implement a code to check following conditions.
-         *
-         * 1. Check if $url is a local server url or a cloud url.
-         * 2. If it is a local server url, check if the file exists on the local server.
-         * 3. If the file exists on the local server, return the local server url.
-         * 4. If the file does not exist on the local server, check if it exists on the cloud.
-         * 5. If it exists on the cloud, return the cloud url.
-         * 6. If it does not exist on the cloud, return the local server url (which will result in a 404).
-         * 7. If it is a cloud url, check whether this is synced to cloud or not.
-         * 8. If it is synced to cloud, return the cloud url.
-         * 9. If it is not synced to cloud, check if the file exists on the local server.
-         * 10. If the file exists on the local server, return the local server url.
-         * 11. If the file does not exist on the local server, return the cloud url (which will result in a 404).
-         */
+        if ( empty( $url ) || ! is_string( $url ) ) {
+            return $url;
+        }
 
-        // If the file is excluded, always return local URL.
+        // Exclusion: user wants this path served locally, so rewrite CDN → local first.
         if ( InfiniteUploadsHelper::is_path_excluded( $url, true ) ) {
             $url = InfiniteUploadsHelper::get_local_file_url( $url );
         }
 
-        // Get root directories for comparison
-        $root_dirs = $this->iup_instance->get_original_upload_dir_root();
-        $base_url  = $root_dirs['baseurl'];
-        $base_dir  = $root_dirs['basedir'];
-        $cloud_url = untrailingslashit( $this->iup_instance->get_s3_url() );
-
+        $root_dirs    = $this->iup_instance->get_original_upload_dir_root();
+        $base_url     = $root_dirs['baseurl'];
+        $base_dir     = $root_dirs['basedir'];
+        $cloud_url    = untrailingslashit( $this->iup_instance->get_s3_url() );
         $is_local_url = ( strpos( $url, $base_url ) !== false );
 
         if ( $is_local_url ) {
-            $file_path = str_replace( $base_url, $base_dir, $url );
-
-            if ( file_exists( $file_path ) ) {
-                return $url;
-            }
             $relative_path = str_replace( $base_url, '', $url );
-        } else {
-            $relative_path = str_replace( $cloud_url, '', $url );
-        }
+            $local_path    = $base_dir . $relative_path;
 
-        global $wpdb;
-        $is_synced = $wpdb->get_var( $wpdb->prepare(
-                "SELECT synced FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE file = %s AND synced = 1",
-                $relative_path
-        ) );
-
-        if ( $is_local_url ) {
-            return $is_synced ? ( $cloud_url . $relative_path ) : $url;
-        } else {
-            if ( $is_synced ) {
+            if ( file_exists( $local_path ) ) {
                 return $url;
             }
 
-            $local_path = $base_dir . $relative_path;
+            // Local missing — fall back to cloud if the file is actually there.
+            if ( self::cloud_file_exists( $relative_path ) ) {
+                return $cloud_url . $relative_path;
+            }
 
-            return file_exists( $local_path ) ? ( $base_url . $relative_path ) : $url;
+            return $url;
         }
+
+        // Cloud URL path
+        $relative_path = str_replace( $cloud_url, '', $url );
+
+        if ( self::cloud_file_exists( $relative_path ) ) {
+            return $url;
+        }
+
+        // Cloud missing — try local.
+        $local_path = $base_dir . $relative_path;
+        if ( file_exists( $local_path ) ) {
+            return $base_url . $relative_path;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Check whether a given uploads-relative path exists on the IU cloud. Uses the
+     * stream wrapper's per-request stat cache and an additional static memo here so
+     * the same URL checked multiple times on one page costs at most one HeadObject.
+     *
+     * @param string $relative_path Uploads-relative path, leading slash required (e.g. "/2026/04/file.jpg").
+     *
+     * @return bool
+     */
+    private static function cloud_file_exists( $relative_path ) {
+        static $cache = [];
+
+        if ( $relative_path === '' ) {
+            return false;
+        }
+        if ( array_key_exists( $relative_path, $cache ) ) {
+            return $cache[ $relative_path ];
+        }
+
+        $cloud_path = InfiniteUploadsHelper::get_cloud_upload_path() . $relative_path;
+        $exists     = false;
+
+        // Guard: get_cloud_upload_path() may return local path when IU isn't connected.
+        if ( 0 === strpos( $cloud_path, 'iu://' ) ) {
+            $exists = @file_exists( $cloud_path );
+        }
+
+        $cache[ $relative_path ] = $exists;
+
+        return $exists;
     }
 
     public function set_the_new_file_path( $uploaded, $file, $new_file, $type ) {

--- a/inc/InfiniteUploadsAdmin.php
+++ b/inc/InfiniteUploadsAdmin.php
@@ -280,6 +280,146 @@ class InfiniteUploadsAdmin {
         wp_send_json_success( $this->iup_instance->get_sync_stats() );
     }
 
+    public function download_image( $image_path ) {
+        global $wpdb;
+
+        if ( ! current_user_can( $this->iup_instance->capability )  ) {
+            wp_send_json_error( esc_html__( 'Permissions Error: Please refresh the page and try again.', 'infinite-uploads' ) );
+        }
+
+        $upload_dir = wp_upload_dir();
+
+        $to_sync[] = (object) [
+                'file' => $image_path,
+                'size' => file_exists( $upload_dir['basedir'] . $image_path ) ? filesize( $upload_dir['basedir'] . $image_path ) : 0
+        ];
+
+        $downloaded = 0;
+        $errors     = [];
+        $break      = false;
+        $path       = $this->iup_instance->get_original_upload_dir_root();
+        $s3         = $this->iup_instance->s3();
+
+        //build full paths
+        $to_sync_full = [];
+        $to_sync_size = 0;
+        $to_sync_sql  = [];
+        foreach ( $to_sync as $file ) {
+            $to_sync_size += $file->size;
+            if ( count( $to_sync_full ) && $to_sync_size > INFINITE_UPLOADS_SYNC_MAX_BYTES ) { //upload at minimum one file even if it's huuuge
+                break;
+            }
+            $to_sync_full[] = 's3://' . untrailingslashit( $this->iup_instance->bucket ) . $file->file;
+            $to_sync_sql[]  = esc_sql( $file->file );
+        }
+
+        $obj  = new ArrayObject( $to_sync_full );
+        $from = $obj->getIterator();
+
+        $transfer_args = [
+                'concurrency' => INFINITE_UPLOADS_SYNC_CONCURRENCY,
+                'base_dir'    => 's3://' . $this->iup_instance->bucket,
+                'before'      => function ( ClikIT\Infinite_Uploads\Aws\Command $command ) use ( $wpdb, &$downloaded ) {//add middleware to intercept result of each file upload
+                    if ( in_array( $command->getName(), [ 'GetObject' ], true ) ) {
+                        $command->getHandlerList()->appendSign(
+                                Middleware::mapResult( function ( ResultInterface $result ) use ( $wpdb, &$downloaded ) {
+                                    $downloaded ++;
+                                    $file = $this->iup_instance->get_file_from_result( $result );
+                                    return $result;
+                                } )
+                        );
+                    }
+                },
+        ];
+        try {
+            $manager = new Transfer( $s3, $from, $path['basedir'], $transfer_args );
+            $manager->transfer();
+        } catch ( Exception $e ) {
+            //echo $e->__toString();
+            if ( method_exists( $e, 'getRequest' ) ) {
+                $file        = str_replace( untrailingslashit( $path['basedir'] ), '', str_replace( trailingslashit( $this->iup_instance->bucket ), '', $e->getRequest()->getRequestTarget() ) );
+            } else {
+                $errors[] = esc_html__( 'Error downloading file. Queued for retry.', 'infinite-uploads' );
+            }
+        }
+    }
+
+    public function offload_image( $image_path ) {
+        global $wpdb;
+        $uploaded = 0;
+        $errors   = [];
+        $break    = false;
+        $is_done  = false;
+        $path     = $this->iup_instance->get_original_upload_dir_root();
+        $s3       = $this->iup_instance->s3();
+        if ( ! current_user_can( $this->iup_instance->capability ) ) {
+            wp_send_json_error( esc_html__( 'Permissions Error: Please refresh the page and try again.', 'infinite-uploads' ) );
+        }
+        $orig_path = $this->iup_instance->get_original_upload_dir_root();
+        $to_sync[] = (object) [
+                'file' => $image_path,
+                'size' => file_exists( $orig_path['basedir'] . '/' . $image_path ) ? filesize( $orig_path['basedir'] . '/' . $image_path ) : 0
+        ];
+
+        if ( $to_sync ) {
+            //build full paths
+            $to_sync_full = [];
+            $to_sync_size = 0;
+            $to_sync_sql  = [];
+            foreach ( $to_sync as $file ) {
+                $to_sync_size += $file->size;
+                if ( count( $to_sync_full ) && $to_sync_size > INFINITE_UPLOADS_SYNC_MAX_BYTES ) { //upload at minimum one file even if it's huuuge
+                    break;
+                }
+                $to_sync_full[] = $path['basedir'] . $file->file;
+                $to_sync_sql[]  = esc_sql( $file->file );
+            }
+            $concurrency = count( $to_sync_full ) > 1 ? INFINITE_UPLOADS_SYNC_CONCURRENCY : INFINITE_UPLOADS_SYNC_MULTIPART_CONCURRENCY;
+            $obj         = new ArrayObject( $to_sync_full );
+            $from        = $obj->getIterator();
+
+            $transfer_args = [
+                    'concurrency' => $concurrency,
+                    'base_dir'    => $path['basedir'],
+                    'before'      => function ( ClikIT\Infinite_Uploads\Aws\Command $command ) use ( $wpdb, &$uploaded, &$errors, &$part_sizes ) {
+                        //add middleware to modify object headers
+                        if ( in_array( $command->getName(), [ 'PutObject', 'CreateMultipartUpload' ], true ) ) {
+                            /// Expires:
+                            if ( defined( 'INFINITE_UPLOADS_HTTP_EXPIRES' ) ) {
+                                $command['Expires'] = INFINITE_UPLOADS_HTTP_EXPIRES;
+                            }
+                            // Cache-Control:
+                            if ( defined( 'INFINITE_UPLOADS_HTTP_CACHE_CONTROL' ) ) {
+                                if ( is_numeric( INFINITE_UPLOADS_HTTP_CACHE_CONTROL ) ) {
+                                    $command['CacheControl'] = 'max-age=' . INFINITE_UPLOADS_HTTP_CACHE_CONTROL;
+                                } else {
+                                    $command['CacheControl'] = INFINITE_UPLOADS_HTTP_CACHE_CONTROL;
+                                }
+                            }
+                        }
+
+                        if ( in_array( $command->getName(), [ 'PutObject' ], true ) ) {
+                            $this->sync_debug_log( "Uploading key {$command['Key']}" );
+                        }
+
+                    },
+            ];
+            try {
+                $manager = new Transfer( $s3, $from, 's3://' . $this->iup_instance->bucket . '/', $transfer_args );
+                $manager->transfer();
+            } catch ( Exception $e ) {
+                $this->sync_debug_log( "Transfer sync exception: " . $e->__toString() );
+                //echo $e->__toString();
+                if ( method_exists( $e, 'getRequest' ) ) {
+                    $file        = str_replace( trailingslashit( $this->iup_instance->bucket ), '', $e->getRequest()->getRequestTarget() );
+                } else { //I don't know which error case trigger this but it's common
+                    $errors[] = esc_html__( 'Error uploading file. Queued for retry.', 'infinite-uploads' );
+                }
+            }
+        }
+    }
+
+
     public function ajax_sync_errors() {
         global $wpdb;
 

--- a/inc/InfiniteUploadsAdmin.php
+++ b/inc/InfiniteUploadsAdmin.php
@@ -2746,7 +2746,6 @@ class InfiniteUploadsAdmin {
         global $wpdb;
 
         if ( ! empty( $files_to_resync ) ) {
-            error_log( 'There are files to resync' );
             update_site_option( 'iup_do_sync_complete', 'no' );
             $path = $this->iup_instance->get_original_upload_dir_root();
             $path = $path['basedir'];
@@ -2759,18 +2758,13 @@ class InfiniteUploadsAdmin {
 
         if ( ! empty( $files_to_download_from_infinite_upload_server ) ) {
             $files_to_download = get_site_option( 'iup_files_to_downloads', '' );
-            error_log( 'There are files to download from server' );
             update_site_option( 'iup_do_download_complete', 'no' );
 
-            // error_log( 'Files TO Download Before Merge: ' . print_r( $files_to_download, true ) );
             if ( ! is_array( $files_to_download ) ) {
                 $files_to_download = [];
             }
 
             $files_to_download = array_merge( $files_to_download, $files_to_download_from_infinite_upload_server );
-
-            // error_log( 'Files TO Download After Merge: ' . print_r( $files_to_download, true ) );
-
             $files_to_download = array_unique( $files_to_download );
 
             update_site_option( 'iup_files_to_downloads', $files_to_download );
@@ -2808,30 +2802,18 @@ class InfiniteUploadsAdmin {
     public function add_files_to_download() {
         global $wpdb;
 
-        error_log( 'Add Files To Download' );
-        // error_log( '[INFINITE_UPLOADS] Add files to download' );
-        // error_log( '[INFINITE_UPLOADS] Add files to download >> Step 1' );
-
         $path          = $this->iup_instance->get_original_upload_dir_root();
         $base_dir_path = $path['basedir'];
 
         $files = get_site_option( 'iup_files_to_downloads', '' );
 
-        error_log('Files To Download >>>> ' . print_r( $files, true ) );
-
-        /// error_log( "Files to Download: " . print_r( $files, true ) );
         if ( empty( $files ) || ! is_array( $files ) ) {
-            error_log( "No Files To Download >>>>> " );
-
             return false;
         }
         $dirs_to_download = [];
 
-        // error_log( "Setup File Downloads >>>>> " );
         foreach ( $files as $key => $file ) {
-            error_log("Processing File To Download >>>> " . $file );
             if ( $this->is_dir( $file ) ) {
-                error_log("Directory To Download >>>> " . $file );
                 $file                      = '/' . ltrim( trim( $file, $base_dir_path ), '/' );
                 $dirs_to_download[ $file ] = 1;
                 unset( $files[ $key ] );
@@ -2848,12 +2830,7 @@ class InfiniteUploadsAdmin {
             $wpdb->query( $wpdb->prepare( "INSERT INTO `{$wpdb->base_prefix}infinite_uploads_files` (file, size, synced, deleted, errors) VALUES (%s, 0, 1, 1, 1) ON DUPLICATE KEY UPDATE deleted = 1, errors = 1", $file ) );
         }
 
-        error_log('Dirs TO Download >>>> ' . print_r( $dirs_to_download, true ) );
-
-        // error_log( "Dirs to download >>>>> " . print_r( $dirs_to_download, true ) );
-        // Now process directories
         if ( ! empty( $dirs_to_download ) ) {
-            error_log( 'Dirs To Download' );
             update_site_option( 'iup_dirs_to_downloads', $dirs_to_download );
             as_schedule_single_action( time(), 'infinite-uploads-fetch-s3-files-from-directory-to-download' );
         }
@@ -2867,7 +2844,6 @@ class InfiniteUploadsAdmin {
     public function fetch_s3_files_from_directory_to_download() {
         global $wpdb;
 
-        error_log( 'Fetch S3 Files To Download' );
         $dirs = get_site_option( 'iup_dirs_to_downloads', '' );
 
         $this->sync_debug_log( '[INFINITE_UPLOADS] Fetch S3 files from directory to download' );
@@ -2875,8 +2851,6 @@ class InfiniteUploadsAdmin {
         $this->sync_debug_log( "Dirs to download >>>>> " . print_r( $dirs, true ) );
 
         if ( empty( $dirs ) ) {
-            // error_log( "No Dirs To Download >>>>> " );
-
             return;
         }
 
@@ -2896,7 +2870,6 @@ class InfiniteUploadsAdmin {
 
         $timelimit = max( 20, floor( ini_get( 'max_execution_time' ) * .6666 ) );
         try {
-            // error_log( 'Start fetching S3 files from directory to download' );
             $results    = $s3->getPaginator( 'ListObjectsV2', $args );
             $req_count  = $file_count = 0;
             $is_done    = false;
@@ -2950,7 +2923,6 @@ class InfiniteUploadsAdmin {
 
                 //flush new files to db
                 if ( count( $cloud_only_files ) ) {
-                    // error_log( 'Cloud Only Files >>>> ' . print_r( $cloud_only_files, true ) );
                     $values = [];
                     foreach ( $cloud_only_files as $file ) {
                         $values[] = $wpdb->prepare( "(%s,%d,%d,%s,%d,1,1)", $file['name'], $file['size'], $file['mtime'], $file['type'], $file['size'] );
@@ -2961,8 +2933,6 @@ class InfiniteUploadsAdmin {
                     $query .= " ON DUPLICATE KEY UPDATE size = VALUES(size), modified = VALUES(modified), type = VALUES(type), transferred = VALUES(transferred), synced = 1, deleted = 1, errors = 0";
                     $wpdb->query( $query );
                 }
-
-                // error_log( 'File Count Processed in this request: ' );
 
                 if ( ( $timer = timer_stop() ) >= $timelimit ) {
                     as_schedule_single_action( time(), 'infinite-uploads-fetch-s3-files-from-directory-to-download' );
@@ -2983,7 +2953,6 @@ class InfiniteUploadsAdmin {
     public function do_download() {
         global $wpdb;
 
-        error_log( '[Download] Do Download Started.' );
         $downloaded = 0;
         $errors     = [];
         $break      = false;
@@ -3012,7 +2981,6 @@ class InfiniteUploadsAdmin {
             //preset the error count in case request times out. Successful sync will clear error count.
             $wpdb->query( "UPDATE `{$wpdb->base_prefix}infinite_uploads_files` SET errors = ( errors + 1 ) WHERE file IN ('" . implode( "','", $to_sync_sql ) . "')" );
 
-            // error_log( 'Step 2 - Files to be downloaded in this batch>>>>' . print_r( $to_sync_full, true ) );
             $obj  = new \ArrayObject( $to_sync_full );
             $from = $obj->getIterator();
 
@@ -3042,7 +3010,6 @@ class InfiniteUploadsAdmin {
                 $manager->transfer();
             } catch ( Exception $e ) {
                 if ( method_exists( $e, 'getRequest' ) ) {
-                    // error_log( 'Step 3 - Error while downloading files>>>>' . $e->getMessage() );
                     $file = str_replace( untrailingslashit( $path['basedir'] ), '', str_replace( trailingslashit( $this->iup_instance->bucket ), '', $e->getRequest()->getRequestTarget() ) );
                     // TODO: Remove file from the download list if 404.
                     $error_count = $wpdb->get_var( $wpdb->prepare( "SELECT errors FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE file = %s", $file ) );
@@ -3069,17 +3036,13 @@ class InfiniteUploadsAdmin {
         }
 
         if ( $is_done ) {
-            error_log( '[Download] Do Download Completed.' );
             update_site_option( 'iup_do_download_complete', 'yes', true );
-        } else {
-            error_log( '[Download] Do Download Paused. Will resume shortly.' );
         }
     }
 
     public function do_sync() {
         global $wpdb;
 
-        error_log( '[Sync] Do Sync Started.' );
         //this loop has a parallel status check, so we make the timeout 2/3 of max execution time.
         $timelimit = max( 20, floor( ini_get( 'max_execution_time' ) * .6666 ) );
         $this->sync_debug_log( "Ajax time limit: " . $timelimit );
@@ -3319,7 +3282,6 @@ class InfiniteUploadsAdmin {
         }
 
         if ( $is_done ) {
-            error_log( '[Sync] All files synced.' );
             update_site_option( 'iup_do_sync_complete', 'yes', true );
         }
     }

--- a/inc/InfiniteUploadsAdmin.php
+++ b/inc/InfiniteUploadsAdmin.php
@@ -2508,7 +2508,11 @@ class InfiniteUploadsAdmin {
             $child_path = $dir . DIRECTORY_SEPARATOR . $child_name;
             $has_deeper = count( $segments ) > 1;
 
-            $is_path_dir = is_dir( $child_path );
+            // A virtual node is definitively a folder when the relative virtual path has
+            // deeper segments below it. is_dir() alone isn't safe — after "Free Up Local
+            // Storage" wipes local copies, the intermediate directory may no longer exist
+            // on disk even though it's logically a folder in the cloud filelist.
+            $is_path_dir = $has_deeper || is_dir( $child_path );
             $new_node = [
                     "text"     => $child_name,
                     "icon"     => $is_path_dir ? "jstree-folder" : "jstree-file",
@@ -2574,21 +2578,30 @@ class InfiniteUploadsAdmin {
                 wp_send_json_error( 'Invalid directory path.' );
             }
 
-            // Normalize and verify the path is within the upload basedir.
-            // realpath() resolves symlinks and eliminates traversal sequences; if it
-            // returns false the path does not exist on disk and cannot be trusted.
-            $requested_dir = realpath( $requested_dir );
-            if ( $requested_dir === false ) {
-                wp_send_json_error( 'Invalid directory path.' );
-            }
-
-            // Use realpath on the upload_dir too so both sides are canonical.
+            $requested_dir   = rtrim( $requested_dir, DIRECTORY_SEPARATOR . '/' );
             $real_upload_dir = realpath( $upload_dir );
-            if ( $real_upload_dir === false || strpos( $requested_dir, $real_upload_dir ) !== 0 ) {
-                wp_send_json_error( 'Directory is outside the uploads folder.' );
+            if ( $real_upload_dir === false ) {
+                wp_send_json_error( 'Uploads directory is invalid.' );
             }
 
-            $scan_dir = $requested_dir;
+            // If the requested path exists on disk, resolve via realpath (canonical, handles
+            // symlinks). If it doesn't exist — e.g. a virtual folder whose local copy was
+            // wiped by "Free Up Local Storage" — validate lexically against the uploads
+            // basedir so the user can still expand it and see its cloud-only children.
+            $real_requested = realpath( $requested_dir );
+            if ( $real_requested !== false ) {
+                if ( strpos( $real_requested, $real_upload_dir ) !== 0 ) {
+                    wp_send_json_error( 'Directory is outside the uploads folder.' );
+                }
+                $scan_dir = $real_requested;
+            } else {
+                if ( strpos( $requested_dir, $real_upload_dir ) !== 0 ) {
+                    wp_send_json_error( 'Directory is outside the uploads folder.' );
+                }
+                // prepare_directory_tree() already handles missing dirs and falls through
+                // to virtual-path injection.
+                $scan_dir = $requested_dir;
+            }
         }
 
         $sub_dir       = $dir['subdir'];

--- a/inc/InfiniteUploadsHelper.php
+++ b/inc/InfiniteUploadsHelper.php
@@ -124,11 +124,11 @@ class InfiniteUploadsHelper {
 		return self::get_cloud_file_path( $file_path );
 	}
 
-	public static function get_valid_file_url( $url ) {
+	public static function get_valid_file_url( $url, $is_url = false ) {
 		$local_upload_url = self::get_local_upload_url();
 		$local_url        = str_replace( self::get_cloud_upload_url(), $local_upload_url, $url );
 
-		if ( self::is_path_excluded( $local_url ) ) {
+		if ( self::is_path_excluded( $local_url, $is_url ) ) {
 			return $local_url;
 		}
 

--- a/inc/InfiniteUploadsHelper.php
+++ b/inc/InfiniteUploadsHelper.php
@@ -4,6 +4,12 @@ namespace ClikIT\InfiniteUploads;
 
 class InfiniteUploadsHelper {
 	/**
+	 * Request-scoped memoization for expensive lookups (upload dirs, API data, exclusions).
+	 * These values don't change within a single request.
+	 */
+	private static $request_cache = [];
+
+	/**
 	 * Check if a given path is in the list of excluded paths.
 	 *
 	 * @param  string  $path  The file path to check.
@@ -46,15 +52,31 @@ class InfiniteUploadsHelper {
 	 * @return array|false An array of excluded file paths.
 	 */
 	public static function get_excluded_paths() {
+		if ( isset( self::$request_cache['excluded_paths'] ) ) {
+			return self::$request_cache['excluded_paths'];
+		}
+
 		$excluded_files_array = get_site_option( 'iup_excluded_files', '' );
 		if ( ! is_array( $excluded_files_array ) ) {
 			$excluded_files_array = [];
 		}
 
-		return array_map( 'trim', $excluded_files_array );
+		// Drop empty/whitespace-only entries — otherwise stripos() on an empty string
+		// returns 0 (not false) and makes every path appear excluded.
+		$excluded_files_array = array_filter( array_map( 'trim', $excluded_files_array ), 'strlen' );
+
+		self::$request_cache['excluded_paths'] = $excluded_files_array;
+
+		return $excluded_files_array;
 	}
 
 	public static function get_original_upload_dir_root() {
+		// Key cache by blog_id so multisite switch_to_blog() invalidates correctly.
+		$cache_key = 'upload_dir_root_' . get_current_blog_id();
+		if ( isset( self::$request_cache[ $cache_key ] ) ) {
+			return self::$request_cache[ $cache_key ];
+		}
+
 		$siteurl     = get_option( 'siteurl' );
 		$upload_path = trim( get_option( 'upload_path' ) );
 
@@ -110,10 +132,14 @@ class InfiniteUploadsHelper {
 		$basedir = $dir;
 		$baseurl = $url;
 
-		return array(
+		$result = array(
 			'basedir' => $basedir,
 			'baseurl' => $baseurl,
 		);
+
+		self::$request_cache[ $cache_key ] = $result;
+
+		return $result;
 	}
 
 	public static function get_valid_file_path( $file_path ) {
@@ -210,16 +236,25 @@ class InfiniteUploadsHelper {
 	}
 
 	public static function get_iu_api_data() {
+		if ( array_key_exists( 'iu_api_data', self::$request_cache ) ) {
+			return self::$request_cache['iu_api_data'];
+		}
+
 		$api      = InfiniteUploadsApiHandler::get_instance();
 		$api_data = $api->get_site_data();
+
+		self::$request_cache['iu_api_data'] = $api_data;
 
 		return $api_data;
 	}
 
 	public static function get_cloud_upload_dir() {
-		$root_dirs = self::get_original_upload_dir_root();
+		$cache_key = 'cloud_upload_dir_' . get_current_blog_id();
+		if ( isset( self::$request_cache[ $cache_key ] ) ) {
+			return self::$request_cache[ $cache_key ];
+		}
 
-		// error_log( 'Root Dirs: ' . print_r( $root_dirs, true ) );
+		$root_dirs = self::get_original_upload_dir_root();
 
 		$api_data = self::get_iu_api_data();
 		$dirs     = $root_dirs;
@@ -236,6 +271,8 @@ class InfiniteUploadsHelper {
 				}
 			}
 		}
+
+		self::$request_cache[ $cache_key ] = $dirs;
 
 		return $dirs;
 	}

--- a/inc/InfiniteUploadsHelper.php
+++ b/inc/InfiniteUploadsHelper.php
@@ -178,7 +178,6 @@ class InfiniteUploadsHelper {
 			return '';
 		}
 
-		//error_log('[INFINITE_UPLOADS >> get_local_file_path] Getting local file path for: ' . $file_path);
 		$local_upload_path = self::get_local_upload_path();
 		$cloud_upload_path = self::get_cloud_upload_path();
 

--- a/inc/InfiniteUploadsImageEditorImagick.php
+++ b/inc/InfiniteUploadsImageEditorImagick.php
@@ -55,7 +55,6 @@ class InfiniteUploadsImageEditorImagick extends \WP_Image_Editor_Imagick {
 	 * then copy it to the iu:// path as a workaround.
 	 */
 	protected function _save( $image, $filename = null, $mime_type = null ) {
-		error_log( '[INFINITE_UPLOADS >> saving file: ' . $filename );
 		list( $filename, $extension, $mime_type ) = $this->get_output_format( $filename, $mime_type );
 		if ( ! $filename ) {
 			$filename = $this->generate_filename( null, null, $extension );

--- a/inc/InfiniteUploadsImagify.php
+++ b/inc/InfiniteUploadsImagify.php
@@ -1,0 +1,332 @@
+<?php
+
+namespace ClikIT\InfiniteUploads;
+
+use Imagify\Context\ContextInterface;
+
+/**
+ * Imagify compatibility for Infinite Uploads offloaded media.
+ */
+class InfiniteUploadsImagify {
+	/**
+	 * Singleton instance.
+	 *
+	 * @var InfiniteUploadsImagify|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Infinite Uploads instance.
+	 *
+	 * @var InfiniteUploads
+	 */
+	private $infinite_uploads;
+
+	/**
+	 * Get singleton instance.
+	 *
+	 * @return InfiniteUploadsImagify
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	private function __construct() {
+		$this->infinite_uploads = InfiniteUploads::get_instance();
+	}
+
+	/**
+	 * Register Imagify compatibility hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'imagify_cdn', [ $this, 'register_cdn' ], 10, 3 );
+		add_filter( 'imagify_cdn_source', [ $this, 'register_cdn_source' ] );
+		add_filter( 'imagify_webp_picture_process_image', [ $this, 'mark_picture_sources' ], 10, 2 );
+		add_filter( 'option_imagify_settings', [ $this, 'force_picture_delivery' ] );
+		add_filter( 'site_option_imagify_settings', [ $this, 'force_picture_delivery' ] );
+	}
+
+	/**
+	 * Force picture delivery for Imagify next-gen output while IU CDN is enabled.
+	 *
+	 * @param mixed $options Imagify options.
+	 *
+	 * @return mixed
+	 */
+	public function force_picture_delivery( $options ) {
+		if ( ! $this->is_active() || ! is_array( $options ) ) {
+			return $options;
+		}
+
+		$options['display_nextgen_method'] = 'picture';
+		$options['display_webp_method']    = 'picture';
+
+		return $options;
+	}
+
+	/**
+	 * Register Infinite Uploads as Imagify CDN provider.
+	 *
+	 * @param mixed            $cdn      Current CDN instance.
+	 * @param int              $media_id Attachment ID.
+	 * @param ContextInterface $context  Imagify context.
+	 *
+	 * @return mixed
+	 */
+	public function register_cdn( $cdn, $media_id, $context ) {
+		if ( ! $this->is_active() || ! $context instanceof ContextInterface || 'wp' !== $context->get_name() ) {
+			return $cdn;
+		}
+
+		$cloud_path = self::get_attachment_cloud_path( $media_id );
+		if ( ! $cloud_path || 0 !== strpos( $cloud_path, 'iu://' ) ) {
+			return $cdn;
+		}
+
+		if ( InfiniteUploadsHelper::is_file_exclusion_enabled() && InfiniteUploadsHelper::is_path_excluded( $cloud_path ) ) {
+			return $cdn;
+		}
+
+		return new InfiniteUploadsImagifyCDN( $media_id );
+	}
+
+	/**
+	 * Tell Imagify which CDN URL maps to Infinite Uploads.
+	 *
+	 * @param array $source Current source data.
+	 *
+	 * @return array
+	 */
+	public function register_cdn_source( $source ) {
+		if ( ! $this->is_active() ) {
+			return $source;
+		}
+
+		return [
+			'name' => 'Infinite Uploads',
+			'url'  => trailingslashit( $this->infinite_uploads->get_s3_url() ),
+		];
+	}
+
+	/**
+	 * Mark Imagify picture-tag sources as existing when the sidecars live in cloud storage.
+	 *
+	 * @param array  $data  Image data assembled by Imagify.
+	 * @param string $image Original image HTML.
+	 *
+	 * @return array
+	 */
+	public function mark_picture_sources( $data, $image ) {
+		if ( ! $this->is_active() || ! is_array( $data ) ) {
+			return $data;
+		}
+
+		if ( ! empty( $data['src'] ) && is_array( $data['src'] ) ) {
+			$data['src'] = $this->mark_nextgen_formats( $data['src'] );
+		}
+
+		if ( ! empty( $data['srcset'] ) && is_array( $data['srcset'] ) ) {
+			foreach ( $data['srcset'] as $index => $srcset_source ) {
+				if ( is_array( $srcset_source ) ) {
+					$data['srcset'][ $index ] = $this->mark_nextgen_formats( $srcset_source );
+				}
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Mark WebP/AVIF sidecars as present on cloud storage.
+	 *
+	 * @param array $source Source data.
+	 *
+	 * @return array
+	 */
+	private function mark_nextgen_formats( array $source ) {
+		foreach ( [ 'webp', 'avif' ] as $format ) {
+			$url_key    = $format . '_url';
+			$exists_key = $format . '_exists';
+			$path_key   = $format . '_path';
+
+			if ( empty( $source[ $url_key ] ) ) {
+				continue;
+			}
+
+			$cloud_path = self::cloud_path_from_url( $source[ $url_key ] );
+			if ( ! $cloud_path || 0 !== strpos( $cloud_path, 'iu://' ) ) {
+				continue;
+			}
+
+			$source[ $path_key ]   = $cloud_path;
+			$source[ $exists_key ] = file_exists( $cloud_path );
+		}
+
+		return $source;
+	}
+
+	/**
+	 * Build a list of attachment image paths in cloud storage.
+	 *
+	 * @param int  $attachment_id Attachment ID.
+	 * @param bool $include_nextgen Include WebP/AVIF sidecars.
+	 *
+	 * @return array
+	 */
+	public static function get_attachment_cloud_paths( $attachment_id, $include_nextgen = false ) {
+		$paths     = [];
+		$full_path = self::get_attachment_cloud_path( $attachment_id );
+		$meta      = wp_get_attachment_metadata( $attachment_id, true );
+
+		if ( $full_path ) {
+			$paths[] = $full_path;
+		}
+
+		if ( function_exists( 'wp_get_original_image_path' ) ) {
+			$original_path = wp_get_original_image_path( $attachment_id );
+			$original_path = self::cloud_path_from_path( $original_path );
+
+			if ( $original_path ) {
+				$paths[] = $original_path;
+			}
+		}
+
+		if ( $full_path && ! empty( $meta['sizes'] ) && is_array( $meta['sizes'] ) ) {
+			$full_dir = trailingslashit( dirname( $full_path ) );
+
+			foreach ( $meta['sizes'] as $size ) {
+				if ( empty( $size['file'] ) ) {
+					continue;
+				}
+
+				$paths[] = $full_dir . ltrim( $size['file'], '/' );
+			}
+		}
+
+		$paths = array_values( array_unique( array_filter( $paths ) ) );
+
+		if ( ! $include_nextgen ) {
+			return $paths;
+		}
+
+		$nextgen_paths = [];
+		foreach ( $paths as $path ) {
+			foreach ( [ 'webp', 'avif' ] as $format ) {
+				$nextgen_paths[] = $path . '.' . $format;
+			}
+		}
+
+		return array_values( array_unique( array_merge( $paths, $nextgen_paths ) ) );
+	}
+
+	/**
+	 * Build next-gen attachment URLs on the IU CDN.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 *
+	 * @return array
+	 */
+	public static function get_attachment_nextgen_urls( $attachment_id ) {
+		$urls       = [];
+		$cloud_path = InfiniteUploadsHelper::get_cloud_upload_path();
+		$cloud_url  = untrailingslashit( InfiniteUploadsHelper::get_cloud_upload_url() );
+
+		foreach ( self::get_attachment_cloud_paths( $attachment_id, false ) as $path ) {
+			foreach ( [ 'webp', 'avif' ] as $format ) {
+				$urls[] = str_replace( $cloud_path, $cloud_url, $path . '.' . $format );
+			}
+		}
+
+		return array_values( array_unique( $urls ) );
+	}
+
+	/**
+	 * Get the cloud path for an attachment full-size file.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 *
+	 * @return string|false
+	 */
+	public static function get_attachment_cloud_path( $attachment_id ) {
+		$path = get_attached_file( $attachment_id, true );
+
+		return self::cloud_path_from_path( $path );
+	}
+
+	/**
+	 * Convert a URL to the corresponding Infinite Uploads stream path.
+	 *
+	 * @param string $url File URL.
+	 *
+	 * @return string|false
+	 */
+	public static function cloud_path_from_url( $url ) {
+		if ( empty( $url ) || ! is_string( $url ) ) {
+			return false;
+		}
+
+		$url  = strtok( $url, '?#' );
+		$path = wp_parse_url( $url, PHP_URL_PATH );
+
+		if ( empty( $path ) ) {
+			return false;
+		}
+
+		$local_base_path = wp_parse_url( InfiniteUploadsHelper::get_local_upload_url(), PHP_URL_PATH );
+		$cloud_base_path = wp_parse_url( InfiniteUploadsHelper::get_cloud_upload_url(), PHP_URL_PATH );
+
+		if ( $cloud_base_path && 0 === strpos( $path, $cloud_base_path ) ) {
+			return InfiniteUploadsHelper::get_cloud_upload_path() . substr( $path, strlen( $cloud_base_path ) );
+		}
+
+		if ( $local_base_path && 0 === strpos( $path, $local_base_path ) ) {
+			return InfiniteUploadsHelper::get_cloud_upload_path() . substr( $path, strlen( $local_base_path ) );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Convert a local attachment path to its Infinite Uploads stream path.
+	 *
+	 * @param string $path File path.
+	 *
+	 * @return string|false
+	 */
+	public static function cloud_path_from_path( $path ) {
+		if ( empty( $path ) || ! is_string( $path ) ) {
+			return false;
+		}
+
+		if ( 0 === strpos( $path, 'iu://' ) ) {
+			return $path;
+		}
+
+		if ( 0 !== strpos( $path, '/' ) ) {
+			$path = trailingslashit( InfiniteUploadsHelper::get_local_upload_path() ) . ltrim( $path, '/' );
+		}
+
+		return InfiniteUploadsHelper::get_cloud_file_path( $path );
+	}
+
+	/**
+	 * Tell if IU + Imagify integration is available.
+	 *
+	 * @return bool
+	 */
+	private function is_active() {
+		return function_exists( 'infinite_uploads_enabled' )
+			&& infinite_uploads_enabled()
+			&& interface_exists( '\Imagify\CDN\PushCDNInterface' )
+			&& function_exists( 'get_imagify_option' );
+	}
+}

--- a/inc/InfiniteUploadsImagify.php
+++ b/inc/InfiniteUploadsImagify.php
@@ -53,6 +53,128 @@ class InfiniteUploadsImagify {
 		add_filter( 'imagify_webp_picture_process_image', [ $this, 'mark_picture_sources' ], 10, 2 );
 		add_filter( 'option_imagify_settings', [ $this, 'force_picture_delivery' ] );
 		add_filter( 'site_option_imagify_settings', [ $this, 'force_picture_delivery' ] );
+
+		// Optimization lifecycle: Imagify needs files on real disk (curl_file_create
+		// doesn't support stream wrappers). Download from iu:// before the API call,
+		// push optimized + WebP/AVIF sidecars back after.
+		add_filter( 'imagify_before_optimize_size', [ $this, 'before_optimize_size' ], 10, 7 );
+		add_action( 'imagify_after_optimize', [ $this, 'after_optimize' ], 10, 2 );
+		add_action( 'imagify_after_restore_media', [ $this, 'after_restore_media' ], 10, 4 );
+	}
+
+	/**
+	 * Ensure the file to optimize exists on local disk. Imagify uses curl_file_create()
+	 * to POST images to its API — stream wrappers (iu://) are not supported there.
+	 *
+	 * @param  null|\WP_Error                                              $response   Filter in-flight.
+	 * @param  \Imagify\Optimization\Process\ProcessInterface              $process    Imagify optimization process.
+	 * @param  \Imagify\Optimization\File                                  $file       File being optimized.
+	 * @param  string                                                      $thumb_size Thumbnail size name.
+	 * @param  int                                                         $level      Optimization level.
+	 * @param  bool                                                        $next_gen   Whether this is a WebP/AVIF pass.
+	 * @param  bool                                                        $disabled   Whether optimization is disabled for this size.
+	 *
+	 * @return null|\WP_Error
+	 */
+	public function before_optimize_size( $response, $process, $file, $thumb_size, $level, $next_gen, $disabled ) {
+		if ( is_wp_error( $response ) || 'wp' !== $process->get_media()->get_context() ) {
+			return $response;
+		}
+
+		$cdn = $process->get_media()->get_cdn();
+		if ( ! $cdn instanceof InfiniteUploadsImagifyCDN ) {
+			return $response;
+		}
+
+		$local_path = $file->get_path();
+		if ( ! $local_path || file_exists( $local_path ) ) {
+			return $response;
+		}
+
+		$result = $cdn->get_files_from_cdn( [ $local_path ] );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * After Imagify finishes optimizing, push the optimized files and any generated
+	 * WebP/AVIF sidecars from local disk back to iu://.
+	 *
+	 * @param  \Imagify\Optimization\Process\ProcessInterface  $process  Optimization process.
+	 * @param  array                                           $item     Queue item data.
+	 */
+	public function after_optimize( $process, $item ) {
+		if ( 'wp' !== $process->get_media()->get_context() ) {
+			return;
+		}
+
+		$cdn = $process->get_media()->get_cdn();
+		if ( ! $cdn instanceof InfiniteUploadsImagifyCDN ) {
+			return;
+		}
+
+		$cdn->send_to_cdn( ! empty( $item['data']['is_new_upload'] ) );
+	}
+
+	/**
+	 * After Imagify restores a media from backup: push restored originals to iu://,
+	 * then remove any WebP/AVIF sidecars from cloud storage (the restored original is
+	 * un-optimized and its old sidecars are no longer valid).
+	 *
+	 * @param  \Imagify\Optimization\Process\ProcessInterface  $process   Optimization process.
+	 * @param  bool|\WP_Error                                  $response  Restore result.
+	 * @param  array                                           $files     Files before restoration.
+	 * @param  array                                           $data      Optimization data before deletion.
+	 */
+	public function after_restore_media( $process, $response, $files, $data ) {
+		if ( 'wp' !== $process->get_media()->get_context() ) {
+			return;
+		}
+
+		$cdn = $process->get_media()->get_cdn();
+		if ( ! $cdn instanceof InfiniteUploadsImagifyCDN ) {
+			return;
+		}
+
+		if ( is_wp_error( $response ) && 'copy_failed' === $response->get_error_code() ) {
+			// Nothing was restored, nothing to push.
+			return;
+		}
+
+		$cdn->send_to_cdn( false );
+
+		// Collect WebP/AVIF sidecar paths that existed before restore and delete them from cloud.
+		if ( empty( $files ) || ! is_array( $files ) ) {
+			return;
+		}
+
+		$webp_suffix = defined( get_class( $process ) . '::WEBP_SUFFIX' ) ? $process::WEBP_SUFFIX : '@imagify-webp';
+		$avif_suffix = defined( get_class( $process ) . '::AVIF_SUFFIX' ) ? $process::AVIF_SUFFIX : '@imagify-avif';
+		$nextgen_files = [];
+
+		foreach ( $files as $size_name => $size_info ) {
+			if ( empty( $size_info['path'] ) || empty( $size_info['mime-type'] ) ) {
+				continue;
+			}
+			if ( 0 !== strpos( $size_info['mime-type'], 'image/' ) ) {
+				continue;
+			}
+			$base_path = $size_info['path'];
+			foreach ( [ [ $webp_suffix, 'webp' ], [ $avif_suffix, 'avif' ] ] as $suffix_pair ) {
+				list( $size_suffix, $ext ) = $suffix_pair;
+				if ( empty( $data['sizes'][ $size_name . $size_suffix ]['success'] ) ) {
+					continue;
+				}
+				$nextgen_files[] = $base_path . '.' . $ext;
+			}
+		}
+
+		if ( $nextgen_files ) {
+			$cdn->remove_files_from_cdn( $nextgen_files );
+		}
 	}
 
 	/**
@@ -130,15 +252,23 @@ class InfiniteUploadsImagify {
 			return $data;
 		}
 
+		$attachment_id = $this->find_attachment_id( $data );
+
 		if ( ! empty( $data['src'] ) && is_array( $data['src'] ) ) {
-			$data['src'] = $this->mark_nextgen_formats( $data['src'] );
+			$data['src'] = $this->mark_nextgen_formats( $data['src'], $attachment_id, 'full' );
 		}
 
 		if ( ! empty( $data['srcset'] ) && is_array( $data['srcset'] ) ) {
+			$size_map = $this->build_size_map_by_filename( $attachment_id );
 			foreach ( $data['srcset'] as $index => $srcset_source ) {
-				if ( is_array( $srcset_source ) ) {
-					$data['srcset'][ $index ] = $this->mark_nextgen_formats( $srcset_source );
+				if ( ! is_array( $srcset_source ) ) {
+					continue;
 				}
+				$size_name = null;
+				if ( $size_map && ! empty( $srcset_source['src'] ) ) {
+					$size_name = $size_map[ wp_basename( $srcset_source['src'] ) ] ?? null;
+				}
+				$data['srcset'][ $index ] = $this->mark_nextgen_formats( $srcset_source, $attachment_id, $size_name );
 			}
 		}
 
@@ -146,19 +276,26 @@ class InfiniteUploadsImagify {
 	}
 
 	/**
-	 * Mark WebP/AVIF sidecars as present on cloud storage.
+	 * Mark WebP/AVIF sidecars as present on cloud storage. Uses Imagify's own
+	 * `_imagify_data` postmeta as the primary evidence (single DB lookup per
+	 * request) and falls back to `file_exists('iu://...')` only when metadata
+	 * is missing — which is considerably cheaper than a HEAD request per image.
 	 *
-	 * @param array $source Source data.
+	 * @param  array      $source        Source data.
+	 * @param  int|false  $attachment_id Attachment ID (false if not resolvable).
+	 * @param  string|null $size_name    Imagify size key (e.g. "full", "medium").
 	 *
 	 * @return array
 	 */
-	private function mark_nextgen_formats( array $source ) {
+	private function mark_nextgen_formats( array $source, $attachment_id = false, $size_name = null ) {
+		$imagify_data = $attachment_id ? $this->get_imagify_meta( $attachment_id ) : null;
+
 		foreach ( [ 'webp', 'avif' ] as $format ) {
 			$url_key    = $format . '_url';
 			$exists_key = $format . '_exists';
 			$path_key   = $format . '_path';
 
-			if ( empty( $source[ $url_key ] ) ) {
+			if ( empty( $source[ $url_key ] ) || ! empty( $source[ $exists_key ] ) ) {
 				continue;
 			}
 
@@ -167,11 +304,117 @@ class InfiniteUploadsImagify {
 				continue;
 			}
 
-			$source[ $path_key ]   = $cloud_path;
-			$source[ $exists_key ] = file_exists( $cloud_path );
+			$source[ $path_key ] = $cloud_path;
+
+			// Prefer Imagify's own record of successful conversions — avoids a HEAD-per-image.
+			$success = null;
+			if ( $imagify_data && $size_name ) {
+				$suffix        = 'webp' === $format ? '@imagify-webp' : '@imagify-avif';
+				$imagify_key   = $size_name . $suffix;
+				if ( isset( $imagify_data['sizes'][ $imagify_key ]['success'] ) ) {
+					$success = (bool) $imagify_data['sizes'][ $imagify_key ]['success'];
+				}
+			}
+
+			if ( $success === null ) {
+				// Fallback when metadata is absent (older optimizations, 3rd-party converters).
+				$success = file_exists( $cloud_path );
+			}
+
+			$source[ $exists_key ] = $success;
 		}
 
 		return $source;
+	}
+
+	/**
+	 * Get Imagify's stored optimization metadata for an attachment, request-memoized.
+	 *
+	 * @param  int  $attachment_id
+	 *
+	 * @return array|false
+	 */
+	private function get_imagify_meta( $attachment_id ) {
+		static $cache = [];
+
+		if ( array_key_exists( $attachment_id, $cache ) ) {
+			return $cache[ $attachment_id ];
+		}
+
+		$meta             = get_post_meta( $attachment_id, '_imagify_data', true );
+		$cache[ $attachment_id ] = is_array( $meta ) ? $meta : false;
+
+		return $cache[ $attachment_id ];
+	}
+
+	/**
+	 * Build a filename → Imagify size-name map for fast srcset lookup.
+	 *
+	 * @param  int|false  $attachment_id
+	 *
+	 * @return array
+	 */
+	private function build_size_map_by_filename( $attachment_id ) {
+		if ( ! $attachment_id ) {
+			return [];
+		}
+
+		static $cache = [];
+		if ( isset( $cache[ $attachment_id ] ) ) {
+			return $cache[ $attachment_id ];
+		}
+
+		$meta = wp_get_attachment_metadata( $attachment_id, true );
+		$map  = [];
+
+		if ( ! empty( $meta['file'] ) ) {
+			$map[ wp_basename( $meta['file'] ) ] = 'full';
+		}
+
+		if ( ! empty( $meta['sizes'] ) && is_array( $meta['sizes'] ) ) {
+			foreach ( $meta['sizes'] as $size_name => $size_info ) {
+				if ( ! empty( $size_info['file'] ) ) {
+					$map[ $size_info['file'] ] = $size_name;
+				}
+			}
+		}
+
+		$cache[ $attachment_id ] = $map;
+
+		return $map;
+	}
+
+	/**
+	 * Resolve the attachment ID for an image in the HTML output — needed to look up
+	 * Imagify metadata. Uses the full-size src URL's filename against the postmeta index.
+	 *
+	 * @param  array  $data
+	 *
+	 * @return int|false
+	 */
+	private function find_attachment_id( $data ) {
+		if ( empty( $data['src']['src'] ) ) {
+			return false;
+		}
+
+		static $cache = [];
+		$src = strtok( $data['src']['src'], '?#' );
+		if ( isset( $cache[ $src ] ) ) {
+			return $cache[ $src ];
+		}
+
+		global $wpdb;
+		$filename = wp_basename( $src );
+		$id       = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attached_file' AND meta_value LIKE %s LIMIT 1",
+				'%/' . $wpdb->esc_like( $filename )
+			)
+		);
+
+		$cache[ $src ] = $id > 0 ? $id : false;
+
+		return $cache[ $src ];
 	}
 
 	/**

--- a/inc/InfiniteUploadsImagifyCDN.php
+++ b/inc/InfiniteUploadsImagifyCDN.php
@@ -34,11 +34,16 @@ class InfiniteUploadsImagifyCDN implements PushCDNInterface {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * True when the attachment's authoritative copy lives on iu://. Based on
+	 * `get_attached_file()` (which IU filters to `iu://` for offloaded media),
+	 * not on `get_file_path()` — the latter intentionally returns a local path
+	 * so Imagify's optimization pipeline can work with real filesystem paths.
 	 */
 	public function media_is_on_cdn() {
-		$path = $this->get_file_path();
+		$cloud_path = InfiniteUploadsImagify::get_attachment_cloud_path( $this->attachment_id );
 
-		return $path && 0 === strpos( $path, 'iu://' );
+		return $cloud_path && 0 === strpos( $cloud_path, 'iu://' );
 	}
 
 	/**
@@ -96,9 +101,15 @@ class InfiniteUploadsImagifyCDN implements PushCDNInterface {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Imagify writes the optimized files and their WebP/AVIF sidecars to local disk.
+	 * Push each of those to iu://, then delete the local copy — IU is the authoritative
+	 * store and the local copy is only a temp produced during optimization. File
+	 * exclusion is respected: excluded paths stay local and are not unlinked.
 	 */
 	public function send_to_cdn( $is_new_upload ) {
-		$errors = [];
+		$errors            = [];
+		$exclusion_enabled = InfiniteUploadsHelper::is_file_exclusion_enabled();
 
 		foreach ( InfiniteUploadsImagify::get_attachment_cloud_paths( $this->attachment_id, true ) as $cloud_path ) {
 			$local_path = InfiniteUploadsHelper::get_local_file_path( $cloud_path );
@@ -111,11 +122,19 @@ class InfiniteUploadsImagifyCDN implements PushCDNInterface {
 				continue;
 			}
 
+			// Excluded paths are supposed to stay local — don't push or delete.
+			if ( $exclusion_enabled && InfiniteUploadsHelper::is_path_excluded( $local_path ) ) {
+				continue;
+			}
+
 			wp_mkdir_p( dirname( $cloud_path ) );
 
 			if ( ! copy( $local_path, $cloud_path ) ) {
 				$errors[] = $local_path;
+				continue;
 			}
+
+			@unlink( $local_path );
 		}
 
 		if ( $errors ) {
@@ -144,19 +163,32 @@ class InfiniteUploadsImagifyCDN implements PushCDNInterface {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Returns a LOCAL filesystem path, not the `iu://` stream path. Imagify's
+	 * optimization pipeline sends files to the Imagify API via curl_file_create(),
+	 * which does not support stream wrappers — the file must live on real disk
+	 * during optimization. Upload/download between local and iu:// is orchestrated
+	 * by the `imagify_before_optimize_size` / `imagify_after_optimize` hooks.
 	 */
 	public function get_file_path( $file_name = '' ) {
 		if ( 'original' === $file_name && function_exists( 'wp_get_original_image_path' ) ) {
-			return InfiniteUploadsImagify::cloud_path_from_path( wp_get_original_image_path( $this->attachment_id ) );
+			$cloud_path = InfiniteUploadsImagify::cloud_path_from_path( wp_get_original_image_path( $this->attachment_id ) );
+
+			return $cloud_path ? InfiniteUploadsHelper::get_local_file_path( $cloud_path ) : '';
 		}
 
 		$full_path = InfiniteUploadsImagify::get_attachment_cloud_path( $this->attachment_id );
-
-		if ( ! $file_name || ! $full_path ) {
-			return $full_path ? $full_path : '';
+		if ( ! $full_path ) {
+			return '';
 		}
 
-		return trailingslashit( dirname( $full_path ) ) . ltrim( $file_name, '/' );
+		$local_full = InfiniteUploadsHelper::get_local_file_path( $full_path );
+
+		if ( ! $file_name ) {
+			return $local_full;
+		}
+
+		return trailingslashit( dirname( $local_full ) ) . ltrim( $file_name, '/' );
 	}
 
 	/**
@@ -179,11 +211,12 @@ class InfiniteUploadsImagifyCDN implements PushCDNInterface {
 			return InfiniteUploadsImagify::cloud_path_from_path( $file_path );
 		}
 
-		$full_path = $this->get_file_path();
-		if ( ! $full_path ) {
+		// Relative filename — resolve against the attachment's cloud directory.
+		$cloud_full = InfiniteUploadsImagify::get_attachment_cloud_path( $this->attachment_id );
+		if ( ! $cloud_full ) {
 			return false;
 		}
 
-		return trailingslashit( dirname( $full_path ) ) . ltrim( $file_path, '/' );
+		return trailingslashit( dirname( $cloud_full ) ) . ltrim( $file_path, '/' );
 	}
 }

--- a/inc/InfiniteUploadsImagifyCDN.php
+++ b/inc/InfiniteUploadsImagifyCDN.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace ClikIT\InfiniteUploads;
+
+use Imagify\CDN\PushCDNInterface;
+use WP_Error;
+
+/**
+ * Imagify PushCDN adapter for Infinite Uploads.
+ */
+class InfiniteUploadsImagifyCDN implements PushCDNInterface {
+	/**
+	 * Attachment ID.
+	 *
+	 * @var int
+	 */
+	private $attachment_id;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 */
+	public function __construct( $attachment_id ) {
+		$this->attachment_id = (int) $attachment_id;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function is_ready() {
+		return function_exists( 'infinite_uploads_enabled' ) && infinite_uploads_enabled();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function media_is_on_cdn() {
+		$path = $this->get_file_path();
+
+		return $path && 0 === strpos( $path, 'iu://' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_files_from_cdn( $file_paths ) {
+		$errors = [];
+
+		foreach ( (array) $file_paths as $file_path ) {
+			$cloud_path = $this->resolve_cloud_path( $file_path );
+
+			if ( ! $cloud_path || ! file_exists( $cloud_path ) ) {
+				$errors[] = $file_path;
+				continue;
+			}
+
+			wp_mkdir_p( dirname( $file_path ) );
+
+			if ( ! copy( $cloud_path, $file_path ) ) {
+				$errors[] = $file_path;
+			}
+		}
+
+		if ( $errors ) {
+			return new WP_Error( 'iu_imagify_cdn_copy_failed', __( 'File(s) could not be copied from Infinite Uploads cloud storage.', 'infinite-uploads' ), $errors );
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function remove_files_from_cdn( $file_paths ) {
+		$errors = [];
+
+		foreach ( (array) $file_paths as $file_path ) {
+			$cloud_path = $this->resolve_cloud_path( $file_path );
+
+			if ( ! $cloud_path ) {
+				continue;
+			}
+
+			if ( file_exists( $cloud_path ) && ! unlink( $cloud_path ) ) {
+				$errors[] = $file_path;
+			}
+		}
+
+		if ( $errors ) {
+			return new WP_Error( 'iu_imagify_cdn_delete_failed', __( 'File(s) could not be removed from Infinite Uploads cloud storage.', 'infinite-uploads' ), $errors );
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function send_to_cdn( $is_new_upload ) {
+		$errors = [];
+
+		foreach ( InfiniteUploadsImagify::get_attachment_cloud_paths( $this->attachment_id, true ) as $cloud_path ) {
+			$local_path = InfiniteUploadsHelper::get_local_file_path( $cloud_path );
+
+			if ( ! $local_path || ! file_exists( $local_path ) ) {
+				continue;
+			}
+
+			if ( $local_path === $cloud_path ) {
+				continue;
+			}
+
+			wp_mkdir_p( dirname( $cloud_path ) );
+
+			if ( ! copy( $local_path, $cloud_path ) ) {
+				$errors[] = $local_path;
+			}
+		}
+
+		if ( $errors ) {
+			return new WP_Error( 'iu_imagify_cdn_upload_failed', __( 'File(s) could not be uploaded to Infinite Uploads cloud storage.', 'infinite-uploads' ), $errors );
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_file_url( $file_name = '' ) {
+		$file_url = wp_get_attachment_url( $this->attachment_id );
+
+		if ( ! $file_url ) {
+			return '';
+		}
+
+		if ( ! $file_name ) {
+			return $file_url;
+		}
+
+		return trailingslashit( dirname( $file_url ) ) . ltrim( $file_name, '/' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_file_path( $file_name = '' ) {
+		if ( 'original' === $file_name && function_exists( 'wp_get_original_image_path' ) ) {
+			return InfiniteUploadsImagify::cloud_path_from_path( wp_get_original_image_path( $this->attachment_id ) );
+		}
+
+		$full_path = InfiniteUploadsImagify::get_attachment_cloud_path( $this->attachment_id );
+
+		if ( ! $file_name || ! $full_path ) {
+			return $full_path ? $full_path : '';
+		}
+
+		return trailingslashit( dirname( $full_path ) ) . ltrim( $file_name, '/' );
+	}
+
+	/**
+	 * Resolve a local or cloud file path to its cloud storage path.
+	 *
+	 * @param string $file_path File path or file name.
+	 *
+	 * @return string|false
+	 */
+	private function resolve_cloud_path( $file_path ) {
+		if ( empty( $file_path ) || ! is_string( $file_path ) ) {
+			return false;
+		}
+
+		if ( 0 === strpos( $file_path, 'iu://' ) ) {
+			return $file_path;
+		}
+
+		if ( 0 === strpos( $file_path, '/' ) ) {
+			return InfiniteUploadsImagify::cloud_path_from_path( $file_path );
+		}
+
+		$full_path = $this->get_file_path();
+		if ( ! $full_path ) {
+			return false;
+		}
+
+		return trailingslashit( dirname( $full_path ) ) . ltrim( $file_path, '/' );
+	}
+}

--- a/inc/InfiniteUploadsImagifyCDN.php
+++ b/inc/InfiniteUploadsImagifyCDN.php
@@ -35,15 +35,23 @@ class InfiniteUploadsImagifyCDN implements PushCDNInterface {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * True when the attachment's authoritative copy lives on iu://. Based on
-	 * `get_attached_file()` (which IU filters to `iu://` for offloaded media),
-	 * not on `get_file_path()` — the latter intentionally returns a local path
-	 * so Imagify's optimization pipeline can work with real filesystem paths.
+	 * True when the attachment's authoritative copy lives on iu://. Excluded paths
+	 * (when file exclusion is enabled) are stored locally, not on the cloud, so
+	 * they return false and Imagify treats them as regular local media.
 	 */
 	public function media_is_on_cdn() {
 		$cloud_path = InfiniteUploadsImagify::get_attachment_cloud_path( $this->attachment_id );
+		if ( ! $cloud_path || 0 !== strpos( $cloud_path, 'iu://' ) ) {
+			return false;
+		}
 
-		return $cloud_path && 0 === strpos( $cloud_path, 'iu://' );
+		if ( InfiniteUploadsHelper::is_file_exclusion_enabled()
+		     && InfiniteUploadsHelper::is_path_excluded( $cloud_path )
+		) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/inc/InfiniteUploadsRewriter.php
+++ b/inc/InfiniteUploadsRewriter.php
@@ -51,7 +51,7 @@ class InfiniteUploadsRewriter {
 		// Build Smush Pro next-gen URL correction pairs.
 		// Smush derives its WebP/AVIF base URL via dirname(wp_upload_dir()['baseurl']), which
 		// strips the last path segment (site_id) from the CDN URL. We fix the resulting bad
-		// CDN URLs in HTML output.
+		// CDN URLs in HTML output and REST API responses.
 		// e.g. https://cdn.example.com/user_id/smush-webp/ → https://cdn.example.com/user_id/site_id/smush-webp/
 		$cdn_no_slash = rtrim( $this->cdn_url, '/' );
 		$last_slash   = strrpos( $cdn_no_slash, '/' );
@@ -68,6 +68,56 @@ class InfiniteUploadsRewriter {
 				}
 			}
 		}
+
+		// Fix Smush next-gen URLs in REST API responses.
+		// WordPress REST API requests bypass template_redirect, so the ob_start approach
+		// does not capture them. Page builders (Elementor, Gutenberg, etc.) fetch attachment
+		// data via /wp-json/wp/v2/media/{id} and use the returned URLs directly; without
+		// this filter those URLs contain the wrong smush-webp CDN path.
+		if ( ! empty( $this->smush_url_fix_pairs ) ) {
+			add_filter( 'rest_prepare_attachment', [ &$this, 'rewrite_rest_attachment' ], 100, 3 );
+		}
+	}
+
+	/**
+	 * Fix Smush next-gen (WebP/AVIF) URLs in WordPress REST API attachment responses.
+	 *
+	 * The ob_start hook on template_redirect does not capture REST API responses.
+	 * This filter serialises the response data to JSON, applies the same
+	 * smush_url_fix_pairs substitutions used by the HTML rewriter, and restores
+	 * the corrected data so consumers receive valid CDN URLs.
+	 *
+	 * @param  \WP_REST_Response  $response  The REST API response object.
+	 * @param  \WP_Post           $post      The attachment post.
+	 * @param  \WP_REST_Request   $request   The REST request.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function rewrite_rest_attachment( $response, $post, $request ) {
+		if ( empty( $this->smush_url_fix_pairs ) || ! ( $response instanceof \WP_REST_Response ) ) {
+			return $response;
+		}
+
+		$data = $response->get_data();
+		$json = wp_json_encode( $data );
+
+		if ( $json === false ) {
+			return $response;
+		}
+
+		$changed = false;
+		foreach ( $this->smush_url_fix_pairs as $bad => $good ) {
+			if ( strpos( $json, $bad ) !== false ) {
+				$json    = str_replace( $bad, $good, $json );
+				$changed = true;
+			}
+		}
+
+		if ( $changed ) {
+			$response->set_data( json_decode( $json, true ) );
+		}
+
+		return $response;
 	}
 
 	/**

--- a/inc/InfiniteUploadsRewriter.php
+++ b/inc/InfiniteUploadsRewriter.php
@@ -43,28 +43,54 @@ class InfiniteUploadsRewriter {
 			}
 		}
 
-		add_action( 'template_redirect', [ &$this, 'handle_rewrite_hook' ] );
+		// Use priority PHP_INT_MIN so our ob_start() fires FIRST on template_redirect,
+		// making our output buffer the OUTERMOST. Other plugins (notably Smush Pro) register
+		// their own ob_start at lower priorities and their callbacks (which inject malformed
+		// https:/smush-webp/… URLs) would otherwise run AFTER ours on buffer close. With
+		// ours outermost, our rewrite() runs LAST and can repair Smush's output.
+		add_action( 'template_redirect', [ &$this, 'handle_rewrite_hook' ], PHP_INT_MIN );
 
 		// Make sure we replace urls in REST API responses
 		add_filter( 'the_content', [ &$this, 'rewrite_the_content' ], 100 );
 
 		// Build Smush Pro next-gen URL correction pairs.
-		// Smush derives its WebP/AVIF base URL via dirname(wp_upload_dir()['baseurl']), which
-		// strips the last path segment (site_id) from the CDN URL. We fix the resulting bad
-		// CDN URLs in HTML output and REST API responses.
-		// e.g. https://cdn.example.com/user_id/smush-webp/ → https://cdn.example.com/user_id/site_id/smush-webp/
+		// Smush derives its WebP/AVIF base URL via dirname(wp_upload_dir()['baseurl']) . '/smush-webp/'.
+		// Two failure modes to fix:
+		//   1. CDN URL has a path (e.g. https://cdn/user_id/site_id) — dirname() strips site_id.
+		//      Fix pair: https://cdn/user_id/smush-webp/ → https://cdn/user_id/site_id/smush-webp/
+		//   2. CDN URL is a vanity host with no path (e.g. https://tenant.infiniteuploads.cloud) —
+		//      dirname() returns just "https:" (scheme + colon), concatenation yields a junk URL
+		//      like https:/smush-webp/... which browsers resolve as a relative path against the
+		//      origin and 404. Fix pair: https:/smush-webp/ → https://cdn/smush-webp/.
 		$cdn_no_slash = rtrim( $this->cdn_url, '/' );
+		$scheme       = wp_parse_url( $cdn_no_slash, PHP_URL_SCHEME );
+		$host         = wp_parse_url( $cdn_no_slash, PHP_URL_HOST );
 		$last_slash   = strrpos( $cdn_no_slash, '/' );
+
 		if ( $last_slash !== false ) {
 			$parent_base = substr( $cdn_no_slash, 0, $last_slash );
-			// Guard: parent must still be a full URL (not just "https:").
-			if ( strpos( $parent_base, '://' ) !== false ) {
-				foreach ( [ 'smush-webp', 'smush-avif' ] as $next_gen_dir ) {
-					$bad  = $parent_base . '/' . $next_gen_dir . '/';
-					$good = $this->cdn_url . $next_gen_dir . '/'; // cdn_url already has trailing slash
+
+			foreach ( [ 'smush-webp', 'smush-avif' ] as $next_gen_dir ) {
+				$good = $this->cdn_url . $next_gen_dir . '/'; // cdn_url already has trailing slash
+
+				// Case 1: dirname gave a valid URL (CDN URL had a path component).
+				if ( strpos( $parent_base, '://' ) !== false ) {
+					$bad = $parent_base . '/' . $next_gen_dir . '/';
 					if ( $bad !== $good ) {
 						$this->smush_url_fix_pairs[ $bad ] = $good;
 					}
+				}
+
+				// Case 2: dirname degenerated to "scheme:" for a host-only CDN URL.
+				// The emitted URL looks like "https:/smush-webp/..." — single slash, no host.
+				if ( $scheme && $host ) {
+					$degenerate = $scheme . ':/' . $next_gen_dir . '/';
+					if ( $degenerate !== $good ) {
+						$this->smush_url_fix_pairs[ $degenerate ] = $good;
+					}
+					// Some PHP builds strip the colon too, producing "/smush-webp/..." — that
+					// also 404s against the origin. Only fix when smush-webp path has no
+					// immediate preceding host segment (distinct from a legitimate local URL).
 				}
 			}
 		}

--- a/inc/InfiniteUploadsStreamWrapper.php
+++ b/inc/InfiniteUploadsStreamWrapper.php
@@ -715,6 +715,17 @@ class InfiniteUploadsStreamWrapper {
 				] ) );
 				$this->debug_cache( 'SET', $cache_key );
 				$this->cacheObjectSet( $cache_key, $file );
+
+				// For file-excluded paths, mirror the write to local disk so the local URL works.
+				if ( InfiniteUploadsHelper::is_file_exclusion_enabled() ) {
+					$local_path = InfiniteUploadsHelper::get_local_file_path( $cache_key );
+					if ( $local_path !== $cache_key && InfiniteUploadsHelper::is_path_excluded( $local_path ) ) {
+						if ( ! is_dir( dirname( $local_path ) ) ) {
+							wp_mkdir_p( dirname( $local_path ) );
+						}
+						file_put_contents( $local_path, $file );
+					}
+				}
 			}
 			unset( $file );
 

--- a/inc/assets/css/media-folders.css
+++ b/inc/assets/css/media-folders.css
@@ -118,10 +118,27 @@
 	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 	padding: 0;
 	box-sizing: border-box;
-	overflow-y: auto;
+	overflow: hidden; /* sidebar itself doesn't scroll; only the tree does */
 	display: flex;
 	flex-direction: column;
 	transition: width 0.2s ease, min-width 0.2s ease, opacity 0.2s ease;
+}
+
+/* Keep header rows (title, actions, virtual folders, search) anchored at the top;
+   only the folder tree below them scrolls. Without this, on short viewports
+   (iPad landscape modal, small laptops) the search textbox could scroll out of
+   view when the tree has many folders. */
+#iu-media-folders-sidebar > .iu-folders-header,
+#iu-media-folders-sidebar > .iu-folders-actions,
+#iu-media-folders-sidebar > .iu-virtual-folders,
+#iu-media-folders-sidebar > .iu-folders-search {
+	flex-shrink: 0;
+}
+
+#iu-media-folders-sidebar > #iu-folders-tree {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
 }
 
 /* Collapsed state */
@@ -1244,6 +1261,60 @@ body.iu-resizing .iu-sidebar-handle::before {
 	.iu-action-rename,
 	.iu-action-delete {
 		padding: 3px 6px;
+	}
+}
+
+/* iPad and similar narrow-tablet widths (portrait ~768-1024px).
+   At these widths WordPress core's mobile stacking rules don't fire (they stop at
+   782px), but the folder sidebar still takes ~280px. The secondary toolbar
+   (type/date filters + sort controls) and primary toolbar (search input) both
+   float inside the remaining frame width, which squeezes the search to zero or
+   overflows offscreen. Force the toolbar to stack and give search its own row. */
+@media screen and (min-width: 601px) and (max-width: 1024px) {
+	.media-frame.iu-has-folders .attachments-browser .media-toolbar {
+		height: auto;
+		min-height: 60px;
+		padding: 8px 0;
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 8px;
+	}
+
+	.media-frame.iu-has-folders .attachments-browser .media-toolbar-primary,
+	.media-frame.iu-has-folders .attachments-browser .media-toolbar-secondary {
+		float: none;
+		width: 100%;
+		max-width: 100%;
+		height: auto;
+	}
+
+	.media-frame.iu-has-folders .attachments-browser .media-toolbar-primary {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		margin: 0;
+	}
+
+	.media-frame.iu-has-folders .attachments-browser .media-toolbar-primary input[type="search"] {
+		flex: 1;
+		min-width: 0;
+		width: auto;
+	}
+
+	/* Let sort + filter controls wrap to a second line instead of squeezing search. */
+	.media-frame.iu-has-folders .media-toolbar-secondary.iu-has-sort {
+		right: auto;
+		flex-wrap: wrap;
+		gap: 4px;
+	}
+
+	/* List-mode search box (upload.php): same stacking rationale. */
+	.iu-media-wrapper .tablenav.top .search-box {
+		float: none;
+		display: flex;
+		align-items: center;
+		margin-top: 6px;
 	}
 }
 

--- a/infinite-uploads.php
+++ b/infinite-uploads.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Infinite Uploads
  * Description: Infinitely scalable cloud storage and delivery for your videos and uploads made easy! Upload directly to cloud storage and manage your files right from the WordPress Media Library.
- * Version: 3.2.1
+ * Version: 3.2.2
  * Author: Infinite Uploads
  * Author URI: https://infiniteuploads.com/?utm_source=iup_plugin&utm_medium=plugin&utm_campaign=iup_plugin&utm_content=meta
  * Text Domain: infinite-uploads
@@ -18,7 +18,7 @@
  * Copyright 2021-2025 ClikIT, LLC
 */
 
-define( 'INFINITE_UPLOADS_VERSION', '3.2.1' );
+define( 'INFINITE_UPLOADS_VERSION', '3.2.2' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
     require_once __DIR__ . '/vendor/autoload.php';

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Requires at least: 6.0
 Tested up to: 6.9
-Stable tag: 3.2.1
+Stable tag: 3.2.2
 Requires PHP: 8.0
 Contributors: bww
 Tags: cloud storage, offload media, offload, video streaming, cdn
@@ -216,13 +216,47 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Upgrade Notice ==
 
-3.2.1
+3.2.2
 -------------
 
-* Fixed an issue where the exclusion file tree was not showing.
-* Fixed a bug causing Infinite Uploads to corrupt plugin ZIP installations from the WordPress admin.
+* **Image Optimizer Compatibility**
+    * EWWW Image Optimizer now works with images stored in the cloud. Both regular and WebP versions are saved and delivered correctly.
+    * Imagify now works end-to-end with cloud-hosted media. Optimized images and their WebP / AVIF versions are kept in sync automatically.
+    * ShortPixel: fixed the "Could not create backup. Please check file permissions" error when optimizing cloud-hosted images.
+    * Smush Pro: fixed broken WebP / AVIF image links that appeared as `https:/smush-webp/...` and resulted in missing images.
+
+* **Page Builder Compatibility**
+    * Elementor, Beaver Builder, and Brizy now load their stylesheets from the correct location when the folder is excluded from cloud sync.
+    * Hardened how Infinite Uploads cooperates with other plugins so its URL fixes always reach the browser.
+
+* **Folder Exclusion Tree**
+    * Fixed an issue where folders appeared as files (and couldn't be expanded) after running "Free Up Local Storage".
+    * Folders that exist only in the cloud now expand correctly so you can browse their contents.
+
+* **Missing Image Fallback**
+    * If a local copy of an image is missing, the plugin now serves it from the cloud automatically instead of showing a broken image. Fixes random 404s after a sync or after freeing up local storage.
 
 == Changelog ==
+
+3.2.2
+----------------------------------------------------------------------
+
+* **Image Optimizer Compatibility**
+    * EWWW Image Optimizer now works with images stored in the cloud. Both regular and WebP versions are saved and delivered correctly.
+    * Imagify now works end-to-end with cloud-hosted media. Optimized images and their WebP / AVIF versions are kept in sync automatically.
+    * ShortPixel: fixed the "Could not create backup. Please check file permissions" error when optimizing cloud-hosted images.
+    * Smush Pro: fixed broken WebP / AVIF image links that appeared as `https:/smush-webp/...` and resulted in missing images.
+
+* **Page Builder Compatibility**
+    * Elementor, Beaver Builder, and Brizy now load their stylesheets from the correct location when the folder is excluded from cloud sync.
+    * Hardened how Infinite Uploads cooperates with other plugins so its URL fixes always reach the browser.
+
+* **Folder Exclusion Tree**
+    * Fixed an issue where folders appeared as files (and couldn't be expanded) after running "Free Up Local Storage".
+    * Folders that exist only in the cloud now expand correctly so you can browse their contents.
+
+* **Missing Image Fallback**
+    * If a local copy of an image is missing, the plugin now serves it from the cloud automatically instead of showing a broken image. Fixes random 404s after a sync or after freeing up local storage.
 
 3.2.1
 ----------------------------------------------------------------------

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ Move, encode, and serve all your video and other media files from the cloud to b
 
 == Description ==
 
-**Infinite Uploads is your all-in-one media solution with video hosting, encoding, and streaming, and a cloud storage and CDN delivery provider for your WordPress media library. It allows you to easily connect an unlimited number of sites to your Infinite Uploads cloud account for offloading your files, handling massive video uploads and encoding them, lowering hosting costs, improving site performance, and serving files faster to your visitors.**
+**Infinite Uploads is your all-in-one media solution: cloud storage, global CDN delivery, video hosting with encoding and streaming, and media library organization with folders and sorting, all fully managed for the WordPress media library. Connect an unlimited number of sites and offload every upload to the cloud automatically. Unlike plugins that require you to configure Amazon S3, Cloudflare R2, Google Cloud Storage, DigitalOcean Spaces, or Azure Blob yourself, Infinite Uploads handles the infrastructure. No API keys, no IAM policies, no CloudFront distribution setup. Handle massive.**
 
 [youtube https://youtu.be/wanINaK0u5M]
 
@@ -60,6 +60,7 @@ Upload directly to your Infinite Uploads cloud storage and manage your files rig
 - **Sort and enhanced search** – sort files by 8 fields (date added, date modified, title, filename, author, file type, extension, file size) and sort folders by name, date created, date modified, or folder size. Search by title, filename, alt text, description, caption, or folder name.
 - **Resizable folder sidebar** – multiple folder tree themes including a Dropbox-style icon view
 - **Page builder folder support** – folders appear in the media picker inside Elementor, Divi, Bricks, Gutenberg, Beaver Builder, Oxygen, Brizy, and WooCommerce
+- **One-click media migration** — migrate your existing WordPress media library to the cloud without touching S3 buckets or CDN configurations.
 
 ### Better Performance, Less Time, Lower-cost
 If you upload a lot of images, publish video content, share motion graphics, want to add big beautiful video backgrounds, have a podcast, or stream large audio files for sermons or lectures, you will save time, resources, and improve performance by moving your files to Infinite Uploads. Keep your site moving at top-speed with dedicated media delivery that seamlessly integrates with WordPress.
@@ -191,6 +192,10 @@ Infinite Uploads is a hybrid custom stack built and hosted with multiple enterpr
 There are plugins for that, but they all have expensive per-site or per-file annual license fees. And then you have to figure out how to signup for and configure complicated cloud providers and CDNs.
 Finally, while the per/GB prices of cloud storage may seem cheap, there are all the hidden costs you don't realize like class A/B/C/D API transaction costs, and bandwidth x3 (to cloud > to cdn > to user). Bandwidth costs alone can often total 8x more than your storage bill!
 Infinite Uploads makes the power of the cloud simple and affordable for non-cloud architects like you.
+
+= How does Infinite Uploads compare to other S3 offload plugins? =
+
+The main difference is that Infinite Uploads is an all-in-one solution: the plugin, cloud storage, video hosting and transcoding, media folders, media library sorting, and global CDN delivery are all included. Most other offload plugins are bring-your-own-bucket, meaning you configure an Amazon S3, Cloudflare R2, or similar account separately, pay that provider's storage, API request, and egress fees, then connect the plugin. That works if you're comfortable managing cloud infrastructure and multiple providers. Infinite Uploads is built for site owners who want to offload media to the cloud without becoming a cloud architect. No API keys, no bucket policies, no CloudFront distribution, no per-site license fees. One connection, flat predictable pricing, and zero infrastructure to manage.
 
 = How can I report security bugs? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ Move, encode, and serve all your video and other media files from the cloud to b
 
 Organize your WordPress Media Library with unlimited nested folders, drag-and-drop file management, sorting, search, and color-coded folders. Included with all paid Infinite Uploads plans. No extra plugin. No extra cost.
 
-Create folders, nest them as deep as you need, and move files individually or in bulk. Upload directly into specific folders from your computer, including full folder structures. Sort files by name, title, author, date, size, or file type. Search files and folders by name in the grid and modal views.
+Create folders, nest them as deep as you need, and move files individually or in bulk. Upload directly into specific folders from your computer, including full folder structures. Sort files by date added, date modified, title, filename, author, file type, extension, or file size. Search across title, filename, alt text, description, caption, and folder name in the grid and modal views.
 
 Folders appear in the media picker across all major page builders: Elementor, Divi, Bricks, Gutenberg/FSE, Beaver Builder, Oxygen, Brizy, and WooCommerce product galleries.
 
@@ -57,7 +57,7 @@ Upload directly to your Infinite Uploads cloud storage and manage your files rig
 - **Universal compatibility** - Works with most well-coded plugins and themes including eCommerce and performance optimization
 - **Media Library folders** – unlimited nested folders with drag-and-drop, color coding, and bulk actions
 - **Folder upload** – upload files directly into a specific folder, including full folder structures from your computer
-- **Sort and enhanced search** – sort files by name, title, author, date added, date modified, size, or file type. Search files and folders by name.
+- **Sort and enhanced search** – sort files by 8 fields (date added, date modified, title, filename, author, file type, extension, file size) and sort folders by name, date created, date modified, or folder size. Search by title, filename, alt text, description, caption, or folder name.
 - **Resizable folder sidebar** – multiple folder tree themes including a Dropbox-style icon view
 - **Page builder folder support** – folders appear in the media picker inside Elementor, Divi, Bricks, Gutenberg, Beaver Builder, Oxygen, Brizy, and WooCommerce
 
@@ -244,9 +244,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
     * Resizable folder sidebar
 
 * **Sorting and Enhanced Search**
-    * Sort files by name, title, author, date added, date modified, size, and file type
+    * Sort files by date added, date modified, title, filename, author, file type, extension, and file size
     * Sort folders by name, date created, date modified, and folder size
-    * Search files and folders by name in the Media Library grid and modal
+    * Search files and folders across title, filename, alt text, description, caption, and folder name in the Media Library grid and modal
 
 * **Page Builder Compatibility**
     * Folders appear in the media picker across all major page builders and plugins:


### PR DESCRIPTION
* **Image Optimizer Compatibility**
    * EWWW Image Optimizer now works with images stored in the cloud. Both regular and WebP versions are saved and delivered correctly.
    * Imagify now works end-to-end with cloud-hosted media. Optimized images and their WebP / AVIF versions are kept in sync automatically.
    * ShortPixel: fixed the "Could not create backup. Please check file permissions" error when optimizing cloud-hosted images.
    * Smush Pro: fixed broken WebP / AVIF image links that appeared as `https:/smush-webp/...` and resulted in missing images.

* **Page Builder Compatibility**
    * Elementor, Beaver Builder, and Brizy now load their stylesheets from the correct location when the folder is excluded from cloud sync.
    * Hardened how Infinite Uploads cooperates with other plugins so its URL fixes always reach the browser.

* **Folder Exclusion Tree**
    * Fixed an issue where folders appeared as files (and couldn't be expanded) after running "Free Up Local Storage".
    * Folders that exist only in the cloud now expand correctly so you can browse their contents.

* **Missing Image Fallback**
    * If a local copy of an image is missing, the plugin now serves it from the cloud automatically instead of showing a broken image. Fixes random 404s after a sync or after freeing up local storage.
