### PR TITLE
Fix Beaver Builder Blank Page Issue

### DIFF
--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -2107,6 +2107,263 @@ function infinite_uploads_filter_bb_cache_dir( $dir_info ) {
 add_filter( 'fl_builder_get_cache_dir', '\ClikIT\InfiniteUploads\infinite_uploads_filter_bb_cache_dir', 999 );
 
 /**
+ * BB writes cropped images directly to disk (bypassing the stream wrapper) and
+ * doesn't go through wp_handle_upload, so the file never enters our offload path
+ * normally. This hook fires immediately after FLBuilderPhoto::crop() saves the
+ * file, giving us a reliable point to (a) record the file in the filelist with
+ * synced=0, and (b) schedule an async cron push to the cloud. The rewriter's
+ * sync-gate then keeps serving the local URL until the push completes, avoiding
+ * a 404 window for visitors.
+ *
+ * @param  array              $cropped_path  Array with 'path' and 'url' keys.
+ * @param  \WP_Image_Editor   $editor        Unused.
+ */
+function infinite_uploads_bb_photo_cropped( $cropped_path, $editor = null ) {
+    if ( ! is_array( $cropped_path ) || empty( $cropped_path['path'] ) ) {
+        return;
+    }
+    $file_path = $cropped_path['path'];
+    if ( ! file_exists( $file_path ) ) {
+        return;
+    }
+    if ( ! InfiniteUploadsHelper::is_offloadable_bb_cache_image( $file_path ) ) {
+        return;
+    }
+    if ( ! infinite_uploads_enabled() ) {
+        return;
+    }
+
+    // Convert absolute path → filelist-style relative path (leading slash).
+    $root_dirs = InfiniteUploadsHelper::get_original_upload_dir_root();
+    $base_dir  = untrailingslashit( $root_dirs['basedir'] );
+    if ( strpos( $file_path, $base_dir ) !== 0 ) {
+        return;
+    }
+    $rel = substr( $file_path, strlen( $base_dir ) );
+
+    global $wpdb;
+    $size     = (int) filesize( $file_path );
+    $modified = (int) filemtime( $file_path );
+    $type     = wp_check_filetype( $file_path );
+    $mime     = ! empty( $type['type'] ) ? $type['type'] : 'application/octet-stream';
+
+    // Idempotent insert — ON DUPLICATE KEY UPDATE handles the regen case where BB
+    // overwrites the same crop with new contents. Reset synced=0 so the next cron
+    // pass re-uploads, and clear error counters so it isn't auto-skipped.
+    $wpdb->query( $wpdb->prepare(
+        "INSERT INTO {$wpdb->base_prefix}infinite_uploads_files
+         (file, size, modified, type, errors, synced, deleted, transferred)
+         VALUES (%s, %d, %d, %s, 0, 0, 0, 0)
+         ON DUPLICATE KEY UPDATE size = VALUES(size), modified = VALUES(modified), synced = 0, deleted = 0, transferred = 0, errors = 0",
+        $rel,
+        $size,
+        $modified,
+        $mime
+    ) );
+
+    // Invalidate the rewriter's synced-paths cache so it reloads on next URL match
+    // (otherwise a stale view could mark a freshly-overwritten crop as synced=1).
+    wp_cache_delete( 'iu_bb_cache_synced_paths', 'infinite_uploads' );
+
+    // Schedule async push ~30s out, idempotent across multiple BB photo writes in one request.
+    if ( ! wp_next_scheduled( 'iu_bb_cache_push' ) ) {
+        wp_schedule_single_event( time() + 30, 'iu_bb_cache_push' );
+    }
+}
+
+add_action( 'fl_builder_photo_cropped', '\ClikIT\InfiniteUploads\infinite_uploads_bb_photo_cropped', 10, 2 );
+
+/**
+ * Cron handler: push queued BB cache images (synced=0) to the cloud.
+ *
+ * Runs ~30s after BB writes a new crop. Uses the existing Transfer pipeline
+ * scoped to BB cache files only, updates synced=1 on success, and invalidates
+ * the rewriter cache so visitor requests after this point get CDN URLs.
+ */
+function infinite_uploads_bb_cache_push() {
+    global $wpdb;
+
+    if ( ! infinite_uploads_enabled() ) {
+        return;
+    }
+
+    $instance = InfiniteUploads::get_instance();
+    if ( empty( $instance->bucket ) ) {
+        return;
+    }
+
+    $rows = $wpdb->get_results(
+        "SELECT file, size FROM `{$wpdb->base_prefix}infinite_uploads_files`
+         WHERE synced = 0 AND errors < 3 AND deleted = 0
+         AND file LIKE '%/bb-plugin/cache/%'
+         LIMIT 100"
+    );
+    if ( ! $rows ) {
+        return;
+    }
+
+    $path = $instance->get_original_upload_dir_root();
+    $s3   = $instance->s3();
+
+    $to_sync_full = [];
+    foreach ( $rows as $r ) {
+        $local = $path['basedir'] . $r->file;
+        if ( file_exists( $local ) ) {
+            $to_sync_full[] = $local;
+        } else {
+            // File vanished locally before push — mark deleted so it's skipped next round.
+            $wpdb->update(
+                "{$wpdb->base_prefix}infinite_uploads_files",
+                [ 'deleted' => 1 ],
+                [ 'file' => $r->file ],
+                [ '%d' ],
+                [ '%s' ]
+            );
+        }
+    }
+    if ( ! $to_sync_full ) {
+        return;
+    }
+
+    $obj  = new \ArrayObject( $to_sync_full );
+    $from = $obj->getIterator();
+
+    $concurrency = defined( 'INFINITE_UPLOADS_SYNC_CONCURRENCY' ) ? INFINITE_UPLOADS_SYNC_CONCURRENCY : 5;
+
+    $transfer_args = [
+        'concurrency' => $concurrency,
+        'base_dir'    => $path['basedir'],
+        'before'      => function ( \ClikIT\Infinite_Uploads\Aws\Command $command ) use ( $wpdb, $instance ) {
+            if ( in_array( $command->getName(), [ 'PutObject', 'CreateMultipartUpload' ], true ) ) {
+                if ( defined( 'INFINITE_UPLOADS_HTTP_EXPIRES' ) ) {
+                    $command['Expires'] = INFINITE_UPLOADS_HTTP_EXPIRES;
+                }
+                if ( defined( 'INFINITE_UPLOADS_HTTP_CACHE_CONTROL' ) ) {
+                    $command['CacheControl'] = is_numeric( INFINITE_UPLOADS_HTTP_CACHE_CONTROL )
+                        ? 'max-age=' . INFINITE_UPLOADS_HTTP_CACHE_CONTROL
+                        : INFINITE_UPLOADS_HTTP_CACHE_CONTROL;
+                }
+            }
+            if ( in_array( $command->getName(), [ 'PutObject', 'CompleteMultipartUpload' ], true ) ) {
+                $command->getHandlerList()->appendSign(
+                    \ClikIT\Infinite_Uploads\Aws\Middleware::mapResult( function ( \ClikIT\Infinite_Uploads\Aws\ResultInterface $result ) use ( $wpdb, $instance ) {
+                        $file = $instance->get_file_from_result( $result );
+                        $wpdb->query( $wpdb->prepare(
+                            "UPDATE `{$wpdb->base_prefix}infinite_uploads_files`
+                             SET transferred = size, synced = 1, errors = 0, transfer_status = null
+                             WHERE file = %s",
+                            $file
+                        ) );
+
+                        return $result;
+                    } )
+                );
+            }
+        },
+    ];
+
+    try {
+        $manager = new \ClikIT\Infinite_Uploads\Aws\S3\Transfer( $s3, $from, 's3://' . $instance->bucket . '/', $transfer_args );
+        $manager->transfer();
+
+        // Make freshly synced=1 rows visible to the rewriter on the next page load.
+        wp_cache_delete( 'iu_bb_cache_synced_paths', 'infinite_uploads' );
+
+        // Re-schedule if there's still pending BB cache work (backfill of many existing
+        // crops, or multiple new crops queued at once). The query mirrors the SELECT above
+        // so we only re-run when there's actual work; errors >= 3 are skipped, breaking
+        // any runaway loop on persistent failures.
+        $pending = (int) $wpdb->get_var(
+            "SELECT COUNT(*) FROM `{$wpdb->base_prefix}infinite_uploads_files`
+             WHERE synced = 0 AND errors < 3 AND deleted = 0
+             AND file LIKE '%/bb-plugin/cache/%'"
+        );
+        if ( $pending > 0 && ! wp_next_scheduled( 'iu_bb_cache_push' ) ) {
+            wp_schedule_single_event( time() + 30, 'iu_bb_cache_push' );
+        }
+    } catch ( \Exception $e ) {
+        // Bump the error counter on the rows we attempted so do_sync's retry logic kicks in.
+        $rel_paths = array_map( function ( $r ) {
+            return esc_sql( $r->file );
+        }, $rows );
+        $wpdb->query(
+            "UPDATE `{$wpdb->base_prefix}infinite_uploads_files`
+             SET errors = errors + 1
+             WHERE file IN ('" . implode( "','", $rel_paths ) . "')"
+        );
+        error_log( '[INFINITE_UPLOADS BB Cache Push] ' . $e->getMessage() );
+    }
+}
+
+add_action( 'iu_bb_cache_push', '\ClikIT\InfiniteUploads\infinite_uploads_bb_cache_push' );
+
+/**
+ * One-time backfill: walk /wp-content/uploads/bb-plugin/cache/, insert any
+ * existing cropped images into infinite_uploads_files with synced=0, then
+ * trigger the existing push handler. Sets a flag when complete so it never
+ * re-runs unless the flag is cleared.
+ */
+function infinite_uploads_bb_carveout_backfill() {
+    global $wpdb;
+
+    $cache_dir = WP_CONTENT_DIR . '/uploads/bb-plugin/cache/';
+    if ( ! is_dir( $cache_dir ) ) {
+        update_site_option( 'iup_bb_carveout_backfilled', INFINITE_UPLOADS_VERSION );
+        return;
+    }
+
+    // We always do the queue step (even if sync isn't yet enabled) so that when
+    // the user activates sync later, their backlog is already known to the system.
+    $root_dirs = InfiniteUploadsHelper::get_original_upload_dir_root();
+    $base_dir  = untrailingslashit( $root_dirs['basedir'] );
+
+    $items     = glob( $cache_dir . '*' );
+    $values    = [];
+    $row_count = 0;
+    foreach ( (array) $items as $item ) {
+        if ( ! is_file( $item ) || is_link( $item ) ) {
+            continue;
+        }
+        if ( ! InfiniteUploadsHelper::is_offloadable_bb_cache_image( $item ) ) {
+            continue;
+        }
+        if ( strpos( $item, $base_dir ) !== 0 ) {
+            continue;
+        }
+        $rel      = substr( $item, strlen( $base_dir ) );
+        $size     = (int) filesize( $item );
+        $modified = (int) filemtime( $item );
+        $type     = wp_check_filetype( $item );
+        $mime     = ! empty( $type['type'] ) ? $type['type'] : 'application/octet-stream';
+        $values[] = $wpdb->prepare( "(%s, %d, %d, %s, 0, 0, 0, 0)", $rel, $size, $modified, $mime );
+        $row_count++;
+    }
+
+    if ( $values ) {
+        // Bulk insert in chunks of 500 — same chunk size used by InfiniteUploadsFilelist::flush_to_db.
+        // ON DUPLICATE KEY UPDATE handles the case where a row already exists (e.g. from a manual rescan).
+        $chunks = array_chunk( $values, 500 );
+        foreach ( $chunks as $chunk ) {
+            $sql = "INSERT INTO {$wpdb->base_prefix}infinite_uploads_files
+                    (file, size, modified, type, errors, synced, deleted, transferred)
+                    VALUES " . implode( ',', $chunk ) . "
+                    ON DUPLICATE KEY UPDATE size = VALUES(size), modified = VALUES(modified), deleted = 0";
+            $wpdb->query( $sql );
+        }
+
+        // Kick the push handler if we have cloud sync enabled. Otherwise rows just sit at
+        // synced=0 until the user enables; either way they're tracked.
+        if ( infinite_uploads_enabled() && ! wp_next_scheduled( 'iu_bb_cache_push' ) ) {
+            wp_schedule_single_event( time() + 30, 'iu_bb_cache_push' );
+        }
+    }
+
+    update_site_option( 'iup_bb_carveout_backfilled', INFINITE_UPLOADS_VERSION );
+}
+
+add_action( 'iu_bb_carveout_backfill', '\ClikIT\InfiniteUploads\infinite_uploads_bb_carveout_backfill' );
+
+/**
  * Initialize WPForo working directories.
  *
  * @param  array  $dir  Working directories.

--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -2192,10 +2192,13 @@ function infinite_uploads_bb_cache_push() {
         return;
     }
 
+    // Anchored LIKE (no leading %) so MySQL can use the PRIMARY KEY range scan on
+    // the `file` column. Paths in this table always start with the relative-to-uploads
+    // leading slash, so '/bb-plugin/cache/...' is a literal prefix match.
     $rows = $wpdb->get_results(
         "SELECT file, size FROM `{$wpdb->base_prefix}infinite_uploads_files`
          WHERE synced = 0 AND errors < 3 AND deleted = 0
-         AND file LIKE '%/bb-plugin/cache/%'
+         AND file LIKE '/bb-plugin/cache/%'
          LIMIT 100"
     );
     if ( ! $rows ) {
@@ -2273,10 +2276,11 @@ function infinite_uploads_bb_cache_push() {
         // crops, or multiple new crops queued at once). The query mirrors the SELECT above
         // so we only re-run when there's actual work; errors >= 3 are skipped, breaking
         // any runaway loop on persistent failures.
+        // Anchored LIKE — same indexing reasoning as the SELECT above.
         $pending = (int) $wpdb->get_var(
             "SELECT COUNT(*) FROM `{$wpdb->base_prefix}infinite_uploads_files`
              WHERE synced = 0 AND errors < 3 AND deleted = 0
-             AND file LIKE '%/bb-plugin/cache/%'"
+             AND file LIKE '/bb-plugin/cache/%'"
         );
         if ( $pending > 0 && ! wp_next_scheduled( 'iu_bb_cache_push' ) ) {
             wp_schedule_single_event( time() + 30, 'iu_bb_cache_push' );
@@ -2300,8 +2304,15 @@ add_action( 'iu_bb_cache_push', '\ClikIT\InfiniteUploads\infinite_uploads_bb_cac
 /**
  * One-time backfill: walk /wp-content/uploads/bb-plugin/cache/, insert any
  * existing cropped images into infinite_uploads_files with synced=0, then
- * trigger the existing push handler. Sets a flag when complete so it never
- * re-runs unless the flag is cleared.
+ * trigger the existing push handler.
+ *
+ * Bounded per run by both a file count and an elapsed-time budget so the cron
+ * tick can't exhaust PHP's max_execution_time or memory_limit on large sites.
+ * If iteration doesn't reach the end of the directory in one run, the handler
+ * re-schedules itself; the completion flag is only set once iteration walks
+ * past the last entry. Memory stays flat regardless of directory size — we use
+ * DirectoryIterator (lazy) and the DB itself as the cursor (load the set of
+ * already-known BB cache rows once at the start, skip them during iteration).
  */
 function infinite_uploads_bb_carveout_backfill() {
     global $wpdb;
@@ -2312,44 +2323,76 @@ function infinite_uploads_bb_carveout_backfill() {
         return;
     }
 
-    // We always do the queue step (even if sync isn't yet enabled) so that when
-    // the user activates sync later, their backlog is already known to the system.
+    // Per-run budget. Tuned so a single tick completes comfortably under
+    // WP-cron's effective timeout (which is gated by PHP max_execution_time
+    // when WP isn't running on real cron). 500 prepared rows ≈ 100KB of memory.
+    $max_files       = 500;
+    $max_seconds     = 20;
+    $start_microtime = microtime( true );
+
+    // Cursor: use the DB as the source of truth for "already processed."
+    // Anchored LIKE so the PRIMARY KEY index handles this even on huge tables.
+    $existing = $wpdb->get_col(
+        "SELECT file FROM {$wpdb->base_prefix}infinite_uploads_files
+         WHERE file LIKE '/bb-plugin/cache/%'"
+    );
+    $seen = $existing ? array_flip( $existing ) : [];
+
     $root_dirs = InfiniteUploadsHelper::get_original_upload_dir_root();
     $base_dir  = untrailingslashit( $root_dirs['basedir'] );
 
-    $items     = glob( $cache_dir . '*' );
+    try {
+        $iterator = new \DirectoryIterator( $cache_dir );
+    } catch ( \Exception $e ) {
+        error_log( '[INFINITE_UPLOADS BB Backfill] Failed to open ' . $cache_dir . ': ' . $e->getMessage() );
+        update_site_option( 'iup_bb_carveout_backfilled', INFINITE_UPLOADS_VERSION );
+        return;
+    }
+
     $values    = [];
-    $row_count = 0;
-    foreach ( (array) $items as $item ) {
-        if ( ! is_file( $item ) || is_link( $item ) ) {
+    $processed = 0;
+    $more_work = false;
+
+    foreach ( $iterator as $entry ) {
+        if ( $entry->isDot() || ! $entry->isFile() || $entry->isLink() ) {
             continue;
         }
-        if ( ! InfiniteUploadsHelper::is_offloadable_bb_cache_image( $item ) ) {
+        $abs = $entry->getPathname();
+        if ( ! InfiniteUploadsHelper::is_offloadable_bb_cache_image( $abs ) ) {
             continue;
         }
-        if ( strpos( $item, $base_dir ) !== 0 ) {
+        if ( strpos( $abs, $base_dir ) !== 0 ) {
             continue;
         }
-        $rel      = substr( $item, strlen( $base_dir ) );
-        $size     = (int) filesize( $item );
-        $modified = (int) filemtime( $item );
-        $type     = wp_check_filetype( $item );
+        $rel = substr( $abs, strlen( $base_dir ) );
+        if ( isset( $seen[ $rel ] ) ) {
+            continue; // already queued by an earlier run or by a live fl_builder_photo_cropped event
+        }
+
+        $size     = (int) $entry->getSize();
+        $modified = (int) $entry->getMTime();
+        $type     = wp_check_filetype( $abs );
         $mime     = ! empty( $type['type'] ) ? $type['type'] : 'application/octet-stream';
         $values[] = $wpdb->prepare( "(%s, %d, %d, %s, 0, 0, 0, 0)", $rel, $size, $modified, $mime );
-        $row_count++;
+        $processed++;
+
+        // Stop after the budget is exhausted. Mark "more_work" so we re-schedule below.
+        if ( $processed >= $max_files || ( microtime( true ) - $start_microtime ) > $max_seconds ) {
+            $more_work = true;
+            break;
+        }
     }
 
     if ( $values ) {
-        // Bulk insert in chunks of 500 — same chunk size used by InfiniteUploadsFilelist::flush_to_db.
-        // ON DUPLICATE KEY UPDATE handles the case where a row already exists (e.g. from a manual rescan).
-        $chunks = array_chunk( $values, 500 );
-        foreach ( $chunks as $chunk ) {
-            $sql = "INSERT INTO {$wpdb->base_prefix}infinite_uploads_files
-                    (file, size, modified, type, errors, synced, deleted, transferred)
-                    VALUES " . implode( ',', $chunk ) . "
-                    ON DUPLICATE KEY UPDATE size = VALUES(size), modified = VALUES(modified), deleted = 0";
-            $wpdb->query( $sql );
-        }
+        // Bulk insert. Up to $max_files rows at a time → single INSERT in normal case.
+        // ON DUPLICATE KEY UPDATE makes the operation idempotent if a row was just
+        // added by a concurrent fl_builder_photo_cropped event between our SELECT
+        // and this INSERT.
+        $sql = "INSERT INTO {$wpdb->base_prefix}infinite_uploads_files
+                (file, size, modified, type, errors, synced, deleted, transferred)
+                VALUES " . implode( ',', $values ) . "
+                ON DUPLICATE KEY UPDATE size = VALUES(size), modified = VALUES(modified), deleted = 0";
+        $wpdb->query( $sql );
 
         // Kick the push handler if we have cloud sync enabled. Otherwise rows just sit at
         // synced=0 until the user enables; either way they're tracked.
@@ -2358,6 +2401,18 @@ function infinite_uploads_bb_carveout_backfill() {
         }
     }
 
+    if ( $more_work ) {
+        // Iteration was cut off by the per-run budget. Re-schedule ourselves and
+        // do NOT set the completion flag — the next tick picks up where we
+        // logically left off (the DB cursor will now include the rows we just
+        // inserted, so they'll be skipped automatically).
+        if ( ! wp_next_scheduled( 'iu_bb_carveout_backfill' ) ) {
+            wp_schedule_single_event( time() + 60, 'iu_bb_carveout_backfill' );
+        }
+        return;
+    }
+
+    // Iteration walked past the last entry within budget → backfill complete.
     update_site_option( 'iup_bb_carveout_backfilled', INFINITE_UPLOADS_VERSION );
 }
 

--- a/inc/InfiniteUploadsAdmin.php
+++ b/inc/InfiniteUploadsAdmin.php
@@ -1318,15 +1318,22 @@ class InfiniteUploadsAdmin {
         $errors  = [];
         $path    = $this->iup_instance->get_original_upload_dir_root();
         $break   = false;
+        // SQL-side carve-out: BB cache images are offloaded for CDN delivery but must
+        // STAY on local disk too — if we delete them, Beaver Builder will regenerate
+        // them on the next request, creating a churn cycle (new file → sync → delete →
+        // regen). Skipping at the SELECT level keeps the loop progressing (no infinite
+        // re-fetch of unprocessed rows) and matches the carve-out applied at scan time
+        // in InfiniteUploadsHelper::is_offloadable_bb_cache_image().
+        $carve_out_sql = " AND file NOT LIKE '%/bb-plugin/cache/%'";
         while ( ! $break ) {
-            $to_delete = $wpdb->get_col( "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0 LIMIT 500" );
+            $to_delete = $wpdb->get_col( "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0{$carve_out_sql} LIMIT 500" );
             foreach ( $to_delete as $file ) {
                 @unlink( $path['basedir'] . $file );
                 $wpdb->update( "{$wpdb->base_prefix}infinite_uploads_files", [ 'deleted' => 1 ], [ 'file' => $file ] );
                 $deleted ++;
             }
 
-            $is_done = ! (bool) $wpdb->get_var( "SELECT count(*) FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0" );
+            $is_done = ! (bool) $wpdb->get_var( "SELECT count(*) FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0{$carve_out_sql}" );
             if ( $is_done || timer_stop() >= $this->ajax_timelimit ) {
                 $break = true;
                 wp_send_json_success( array_merge( compact( 'deleted', 'is_done', 'errors' ), $this->iup_instance->get_sync_stats() ) );

--- a/inc/InfiniteUploadsFilelist.php
+++ b/inc/InfiniteUploadsFilelist.php
@@ -213,6 +213,15 @@ class InfiniteUploadsFilelist {
 	 *
 	 */
 	protected function is_excluded( $path ) {
+		// Carve-out: Beaver Builder writes cropped image files into bb-plugin/cache/
+		// next to its per-layout .css/.js. The folder is excluded by '/cache/' and
+		// '/bb-plugin/' rules below, but the cropped images are what BB actually
+		// serves to visitors — we want them offloaded + CDN-delivered. Layout
+		// .css/.js still match the path-based rules below and stay local.
+		if ( InfiniteUploadsHelper::is_offloadable_bb_cache_image( $path ) ) {
+			return false;
+		}
+
 		/**
 		 * Filters the built in list of file/directory exclusions that should not be synced to the Infinite Uploads cloud. Be specific it's a simple strpos() search for the strings.
 		 *

--- a/inc/InfiniteUploadsHelper.php
+++ b/inc/InfiniteUploadsHelper.php
@@ -351,6 +351,34 @@ class InfiniteUploadsHelper {
 	}
 
 	/**
+	 * Identify Beaver Builder cropped IMAGE files inside wp-content/uploads/bb-plugin/cache/.
+	 *
+	 * The folder is otherwise excluded from sync and rewrite via two flat strpos rules
+	 * ('/cache/' default + '/bb-plugin/' compat). Both rules need to stay in place because
+	 * BB also writes its per-layout *.css / *.js files in there, and those have to be served
+	 * from origin (no rewriting, no offload). This predicate is the extension-aware carve-out:
+	 * scanner and rewriter call it BEFORE the exclusion loop so cropped images are offloaded
+	 * and served via the CDN, while layout assets stay excluded.
+	 *
+	 * @param  string  $path  Filesystem path or URL.
+	 *
+	 * @return bool  True if the path is a BB cache image that should be offloaded/rewritten.
+	 */
+	public static function is_offloadable_bb_cache_image( $path ) {
+		if ( ! is_string( $path ) || $path === '' ) {
+			return false;
+		}
+		if ( false === strpos( $path, '/bb-plugin/cache/' ) ) {
+			return false;
+		}
+
+		$clean = wp_parse_url( $path, PHP_URL_PATH );
+		$ext   = strtolower( pathinfo( $clean ?: $path, PATHINFO_EXTENSION ) );
+
+		return in_array( $ext, [ 'jpg', 'jpeg', 'jpe', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'ico' ], true );
+	}
+
+	/**
 	 * Log a backtrace to the error log.
 	 *
 	 * @param $limit

--- a/inc/InfiniteUploadsRewriter.php
+++ b/inc/InfiniteUploadsRewriter.php
@@ -252,8 +252,13 @@ class InfiniteUploadsRewriter {
 			if ( is_array( $cached ) ) {
 				$this->bb_cache_synced = $cached;
 			} else {
+				// Anchored LIKE (no leading %): `file` values in this table are
+				// path-relative-to-uploads-root with a leading slash, so
+				// '/bb-plugin/cache/...' is a literal prefix of every BB cache
+				// row. This lets MySQL use the PRIMARY KEY range scan on the
+				// `file` column instead of doing a full table scan.
 				$rows = $wpdb->get_col(
-					"SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND file LIKE '%/bb-plugin/cache/%'"
+					"SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND file LIKE '/bb-plugin/cache/%'"
 				);
 				$this->bb_cache_synced = $rows ? array_flip( $rows ) : [];
 				wp_cache_set( $cache_key, $this->bb_cache_synced, $cache_group, 60 );

--- a/inc/InfiniteUploadsRewriter.php
+++ b/inc/InfiniteUploadsRewriter.php
@@ -238,10 +238,17 @@ class InfiniteUploadsRewriter {
 	 *
 	 */
 	protected function rewrite_url( $matches ) {
-		//don't filter excluded dirs
-		foreach ( $this->exclusions as $exclusion ) {
-			if ( 0 === strpos( $matches[0], $exclusion ) ) {
-				return $matches[0];
+		//don't filter excluded dirs — EXCEPT for Beaver Builder cropped images,
+		// which live under /bb-plugin/cache/ alongside the layout .css/.js. The
+		// folder is excluded so the layout assets stay local; the image carve-out
+		// lets the actual rendered crops fall through to CDN replacement below.
+		// The user-controlled file exclusion check that follows is still respected
+		// (those are explicit per-site opt-outs, not default chrome exclusions).
+		if ( ! InfiniteUploadsHelper::is_offloadable_bb_cache_image( $matches[0] ) ) {
+			foreach ( $this->exclusions as $exclusion ) {
+				if ( 0 === strpos( $matches[0], $exclusion ) ) {
+					return $matches[0];
+				}
 			}
 		}
 

--- a/inc/InfiniteUploadsRewriter.php
+++ b/inc/InfiniteUploadsRewriter.php
@@ -13,6 +13,7 @@ class InfiniteUploadsRewriter {
 	protected $cdn_url = null;    // CDN URL
 	protected $exclusions = [];
 	protected $smush_url_fix_pairs = [];    // bad smush next-gen URL => correct URL
+	protected $bb_cache_synced = null; // null = not yet loaded; array = hashset of relative paths with synced=1
 
 	/**
 	 * constructor
@@ -229,6 +230,56 @@ class InfiniteUploadsRewriter {
 	}
 
 	/**
+	 * Check whether a BB-cache-image regex match is already synced to the cloud.
+	 *
+	 * Loads the set of synced BB cache file paths from `infinite_uploads_files`
+	 * lazily on first call, caches it on the instance for the rest of the
+	 * request, and looks the regex match up by the relative path stored in the
+	 * `file` column (leading slash, no query string).
+	 *
+	 * @param  array  $matches  Regex match array — $matches[2] holds the path-relative-to-uploads.
+	 *
+	 * @return bool
+	 */
+	protected function is_bb_cache_synced( $matches ) {
+		global $wpdb;
+
+		if ( $this->bb_cache_synced === null ) {
+			$cache_key   = 'iu_bb_cache_synced_paths';
+			$cache_group = 'infinite_uploads';
+			$cached      = wp_cache_get( $cache_key, $cache_group );
+
+			if ( is_array( $cached ) ) {
+				$this->bb_cache_synced = $cached;
+			} else {
+				$rows = $wpdb->get_col(
+					"SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND file LIKE '%/bb-plugin/cache/%'"
+				);
+				$this->bb_cache_synced = $rows ? array_flip( $rows ) : [];
+				wp_cache_set( $cache_key, $this->bb_cache_synced, $cache_group, 60 );
+			}
+		}
+
+		// $matches[2] is the path-after-uploads-root captured by the regex (no leading slash).
+		// `file` column stores the same path with a leading slash (see InfiniteUploadsFilelist::relative_path).
+		$rel = isset( $matches[2] ) ? $matches[2] : '';
+		if ( $rel === '' ) {
+			return false;
+		}
+		// Strip query string / fragment if any leaked in.
+		$q = strpos( $rel, '?' );
+		if ( $q !== false ) {
+			$rel = substr( $rel, 0, $q );
+		}
+		$h = strpos( $rel, '#' );
+		if ( $h !== false ) {
+			$rel = substr( $rel, 0, $h );
+		}
+
+		return isset( $this->bb_cache_synced[ '/' . $rel ] );
+	}
+
+	/**
 	 * rewrite url
 	 *
 	 * @param  string  $matches  the matches from regex
@@ -244,7 +295,16 @@ class InfiniteUploadsRewriter {
 		// lets the actual rendered crops fall through to CDN replacement below.
 		// The user-controlled file exclusion check that follows is still respected
 		// (those are explicit per-site opt-outs, not default chrome exclusions).
-		if ( ! InfiniteUploadsHelper::is_offloadable_bb_cache_image( $matches[0] ) ) {
+		if ( InfiniteUploadsHelper::is_offloadable_bb_cache_image( $matches[0] ) ) {
+			// Sync gate: BB writes cropped images directly to disk and bypasses
+			// the stream wrapper, so the file may exist locally but not yet on the
+			// CDN (initial backfill window, or the ~minute lag between BB's write
+			// and our scheduled async push). Returning the local URL until the
+			// row is marked synced=1 avoids visitor-facing 404s.
+			if ( ! $this->is_bb_cache_synced( $matches ) ) {
+				return $matches[0];
+			}
+		} else {
 			foreach ( $this->exclusions as $exclusion ) {
 				if ( 0 === strpos( $matches[0], $exclusion ) ) {
 					return $matches[0];

--- a/inc/InfiniteUploadsWPCLICommand.php
+++ b/inc/InfiniteUploadsWPCLICommand.php
@@ -439,8 +439,12 @@ class InfiniteUploadsWPCLICommand extends \WP_CLI_Command {
 		}
 
 		//begin deleting
+		// Carve-out: BB cache images are offloaded but must stay local (BB regenerates
+		// missing files → sync churn). Filter at SELECT level so the count and progress
+		// bar reflect actual delete targets. Matches the scan-time carve-out in
+		// InfiniteUploadsHelper::is_offloadable_bb_cache_image().
 		$deleted      = 0;
-		$to_delete    = $wpdb->get_col( "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0" );
+		$to_delete    = $wpdb->get_col( "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0 AND file NOT LIKE '%/bb-plugin/cache/%'" );
 		$progress_bar = null;
 		if ( ! $args_assoc['verbose'] ) {
 			$progress_bar = \WP_CLI\Utils\make_progress_bar( esc_html__( 'Deleting local copies of synced files...', 'infinite-uploads' ), count( $to_delete ) );

--- a/inc/MediaFolders.php
+++ b/inc/MediaFolders.php
@@ -623,6 +623,11 @@ class MediaFolders {
 
 		$folder_id = (int) $wpdb->insert_id;
 
+		// Folder set changed → invalidate cached dropdown options used by
+		// integrations (Beaver Builder module, etc.). Match the key/group used
+		// by _iu_bb_get_folder_options() in inc/gallery/integrations/BeaverModule.php.
+		wp_cache_delete( 'iu_bb_folder_options', 'infinite_uploads' );
+
 		wp_send_json_success( [
 			'id'        => 'folder_' . $folder_id,
 			'text'      => $name,
@@ -671,6 +676,9 @@ class MediaFolders {
 		if ( false === $updated ) {
 			wp_send_json_error( __( 'Failed to rename folder.', 'infinite-uploads' ) );
 		}
+
+		// Folder name changed → invalidate cached dropdown options (see ajax_create_folder).
+		wp_cache_delete( 'iu_bb_folder_options', 'infinite_uploads' );
 
 		wp_send_json_success( [ 'term_id' => $folder_id, 'name' => $name ] );
 	}
@@ -730,6 +738,9 @@ class MediaFolders {
 			[ 'id' => $folder_id ],
 			[ '%d' ]
 		);
+
+		// Folder removed → invalidate cached dropdown options (see ajax_create_folder).
+		wp_cache_delete( 'iu_bb_folder_options', 'infinite_uploads' );
 
 		wp_send_json_success( [ 'deleted' => $folder_id ] );
 	}
@@ -832,6 +843,11 @@ class MediaFolders {
 				"UPDATE {$this->folders_table()} SET parent_id = 0 WHERE parent_id IN ($placeholders)",
 				...$deleted
 			) );
+		}
+
+		// Folder set changed → invalidate cached dropdown options (see ajax_create_folder).
+		if ( ! empty( $deleted ) ) {
+			wp_cache_delete( 'iu_bb_folder_options', 'infinite_uploads' );
 		}
 
 		wp_send_json_success( [ 'deleted' => $deleted ] );

--- a/inc/gallery/integrations/BeaverModule.php
+++ b/inc/gallery/integrations/BeaverModule.php
@@ -33,20 +33,40 @@ class IU_Gallery_BB_Module extends \FLBuilderModule {
 /**
  * Build folder options for the module's settings form.
  *
- * Runs only when the Beaver Builder admin UI renders our module's fields, NOT
- * on every front-end page load — that's enforced by the init-hook wrapper
- * around register_module() below.
+ * Called from inside the `init`-hooked register_module() below, which fires on
+ * every request (front-end, admin, AJAX). Without caching the underlying
+ * `SELECT id, name FROM wp_infinite_uploads_media_folders` would run on every
+ * page load on every site that has Beaver Builder active — wasted load,
+ * especially on front-end requests that never touch the editor. The 5-min
+ * object cache collapses that to one query per server per 5 minutes
+ * (instantaneous when a persistent cache like Redis/Memcached is in front of
+ * wp_cache), and the cache is invalidated explicitly by MediaFolders.php on
+ * create / rename / delete so the dropdown never goes stale.
+ *
+ * Folder names are escaped before storing in the option array. They're user-
+ * supplied (anyone with `upload_files` can create one), and BB does sanitise
+ * its rendered <option> labels — but escaping here is defence in depth in
+ * case the value flows somewhere unsanitised in BB's UI later.
  *
  * @return array
  */
 function _iu_bb_get_folder_options() {
+	$cache_key   = 'iu_bb_folder_options';
+	$cache_group = 'infinite_uploads';
+	$cached      = wp_cache_get( $cache_key, $cache_group );
+	if ( is_array( $cached ) ) {
+		return $cached;
+	}
+
 	global $wpdb;
 	$table = $wpdb->prefix . 'infinite_uploads_media_folders';
 	$rows  = $wpdb->get_results( "SELECT id, name FROM {$table} ORDER BY name ASC", ARRAY_A );
 	$opts  = [ '0' => esc_html__( '— Select a folder —', 'infinite-uploads' ) ];
 	foreach ( (array) $rows as $row ) {
-		$opts[ (string) $row['id'] ] = $row['name'];
+		$opts[ (string) $row['id'] ] = esc_html( $row['name'] );
 	}
+
+	wp_cache_set( $cache_key, $opts, $cache_group, 5 * MINUTE_IN_SECONDS );
 	return $opts;
 }
 

--- a/inc/gallery/integrations/BeaverModule.php
+++ b/inc/gallery/integrations/BeaverModule.php
@@ -30,7 +30,15 @@ class IU_Gallery_BB_Module extends \FLBuilderModule {
 	}
 }
 
-// Build folder options for the form.
+/**
+ * Build folder options for the module's settings form.
+ *
+ * Runs only when the Beaver Builder admin UI renders our module's fields, NOT
+ * on every front-end page load — that's enforced by the init-hook wrapper
+ * around register_module() below.
+ *
+ * @return array
+ */
 function _iu_bb_get_folder_options() {
 	global $wpdb;
 	$table = $wpdb->prefix . 'infinite_uploads_media_folders';
@@ -42,85 +50,106 @@ function _iu_bb_get_folder_options() {
 	return $opts;
 }
 
-\FLBuilder::register_module( 'ClikIT\InfiniteUploads\IU_Gallery_BB_Module', [
-	'general' => [
-		'title'    => esc_html__( 'General', 'infinite-uploads' ),
-		'sections' => [
-			'main' => [
-				'title'  => esc_html__( 'Gallery Settings', 'infinite-uploads' ),
-				'fields' => [
-					'folder_id'  => [
-						'type'    => 'select',
-						'label'   => esc_html__( 'Folder', 'infinite-uploads' ),
-						'default' => '0',
-						'options' => _iu_bb_get_folder_options(),
-					],
-					'columns'    => [
-						'type'    => 'unit',
-						'label'   => esc_html__( 'Columns', 'infinite-uploads' ),
-						'default' => '3',
-					],
-					'image_size' => [
-						'type'    => 'select',
-						'label'   => esc_html__( 'Image Size', 'infinite-uploads' ),
-						'default' => 'medium',
-						'options' => [
-							'thumbnail' => esc_html__( 'Thumbnail', 'infinite-uploads' ),
-							'medium'    => esc_html__( 'Medium', 'infinite-uploads' ),
-							'large'     => esc_html__( 'Large', 'infinite-uploads' ),
-							'full'      => esc_html__( 'Full Size', 'infinite-uploads' ),
+/**
+ * Register the module via the `init` action so Beaver Builder is fully
+ * initialised before we touch its module registry.
+ *
+ * Calling FLBuilder::register_module() at file-load time (i.e. during
+ * plugins_loaded, which is when MediaFoldersGallery::init_integrations()
+ * pulls this file in) is too early: BB hasn't yet built its internal module
+ * list. Our registration then either disappears when BB resets the list, or
+ * partially populates state that breaks BB's later initialisation — the
+ * observable symptoms are "other modules disappear from the BB list" and a
+ * fatal that blanks the front page during render.
+ *
+ * Priority 11 runs after BB's own init handlers (which register at priority
+ * 10) and matches the pattern used by BB's own example modules.
+ */
+add_action( 'init', function () {
+	if ( ! class_exists( '\FLBuilder' ) || ! method_exists( '\FLBuilder', 'register_module' ) ) {
+		return;
+	}
+
+	\FLBuilder::register_module( 'ClikIT\InfiniteUploads\IU_Gallery_BB_Module', [
+		'general' => [
+			'title'    => esc_html__( 'General', 'infinite-uploads' ),
+			'sections' => [
+				'main' => [
+					'title'  => esc_html__( 'Gallery Settings', 'infinite-uploads' ),
+					'fields' => [
+						'folder_id'  => [
+							'type'    => 'select',
+							'label'   => esc_html__( 'Folder', 'infinite-uploads' ),
+							'default' => '0',
+							'options' => _iu_bb_get_folder_options(),
 						],
-					],
-					'link_to'    => [
-						'type'    => 'select',
-						'label'   => esc_html__( 'Link To', 'infinite-uploads' ),
-						'default' => 'none',
-						'options' => [
-							'none'       => esc_html__( 'None', 'infinite-uploads' ),
-							'file'       => esc_html__( 'Media File', 'infinite-uploads' ),
-							'attachment' => esc_html__( 'Attachment Page', 'infinite-uploads' ),
+						'columns'    => [
+							'type'    => 'unit',
+							'label'   => esc_html__( 'Columns', 'infinite-uploads' ),
+							'default' => '3',
 						],
-					],
-					'orderby'    => [
-						'type'    => 'select',
-						'label'   => esc_html__( 'Order By', 'infinite-uploads' ),
-						'default' => 'date',
-						'options' => [
-							'date'  => esc_html__( 'Date', 'infinite-uploads' ),
-							'title' => esc_html__( 'Title', 'infinite-uploads' ),
-							'rand'  => esc_html__( 'Random', 'infinite-uploads' ),
+						'image_size' => [
+							'type'    => 'select',
+							'label'   => esc_html__( 'Image Size', 'infinite-uploads' ),
+							'default' => 'medium',
+							'options' => [
+								'thumbnail' => esc_html__( 'Thumbnail', 'infinite-uploads' ),
+								'medium'    => esc_html__( 'Medium', 'infinite-uploads' ),
+								'large'     => esc_html__( 'Large', 'infinite-uploads' ),
+								'full'      => esc_html__( 'Full Size', 'infinite-uploads' ),
+							],
 						],
-					],
-					'order'      => [
-						'type'    => 'select',
-						'label'   => esc_html__( 'Order', 'infinite-uploads' ),
-						'default' => 'DESC',
-						'options' => [
-							'DESC' => esc_html__( 'Descending', 'infinite-uploads' ),
-							'ASC'  => esc_html__( 'Ascending', 'infinite-uploads' ),
+						'link_to'    => [
+							'type'    => 'select',
+							'label'   => esc_html__( 'Link To', 'infinite-uploads' ),
+							'default' => 'none',
+							'options' => [
+								'none'       => esc_html__( 'None', 'infinite-uploads' ),
+								'file'       => esc_html__( 'Media File', 'infinite-uploads' ),
+								'attachment' => esc_html__( 'Attachment Page', 'infinite-uploads' ),
+							],
 						],
-					],
-					'lightbox'   => [
-						'type'    => 'select',
-						'label'   => esc_html__( 'Enable Lightbox', 'infinite-uploads' ),
-						'default' => '0',
-						'options' => [
-							'0' => esc_html__( 'No', 'infinite-uploads' ),
-							'1' => esc_html__( 'Yes', 'infinite-uploads' ),
+						'orderby'    => [
+							'type'    => 'select',
+							'label'   => esc_html__( 'Order By', 'infinite-uploads' ),
+							'default' => 'date',
+							'options' => [
+								'date'  => esc_html__( 'Date', 'infinite-uploads' ),
+								'title' => esc_html__( 'Title', 'infinite-uploads' ),
+								'rand'  => esc_html__( 'Random', 'infinite-uploads' ),
+							],
 						],
-					],
-					'caption'    => [
-						'type'    => 'select',
-						'label'   => esc_html__( 'Show Captions', 'infinite-uploads' ),
-						'default' => '0',
-						'options' => [
-							'0' => esc_html__( 'No', 'infinite-uploads' ),
-							'1' => esc_html__( 'Yes', 'infinite-uploads' ),
+						'order'      => [
+							'type'    => 'select',
+							'label'   => esc_html__( 'Order', 'infinite-uploads' ),
+							'default' => 'DESC',
+							'options' => [
+								'DESC' => esc_html__( 'Descending', 'infinite-uploads' ),
+								'ASC'  => esc_html__( 'Ascending', 'infinite-uploads' ),
+							],
+						],
+						'lightbox'   => [
+							'type'    => 'select',
+							'label'   => esc_html__( 'Enable Lightbox', 'infinite-uploads' ),
+							'default' => '0',
+							'options' => [
+								'0' => esc_html__( 'No', 'infinite-uploads' ),
+								'1' => esc_html__( 'Yes', 'infinite-uploads' ),
+							],
+						],
+						'caption'    => [
+							'type'    => 'select',
+							'label'   => esc_html__( 'Show Captions', 'infinite-uploads' ),
+							'default' => '0',
+							'options' => [
+								'0' => esc_html__( 'No', 'infinite-uploads' ),
+								'1' => esc_html__( 'Yes', 'infinite-uploads' ),
+							],
 						],
 					],
 				],
 			],
 		],
-	],
-] );
+	] );
+}, 11 );
 

--- a/infinite-uploads.php
+++ b/infinite-uploads.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: Infinite Uploads
  * Description: Infinitely scalable cloud storage and delivery for your videos and uploads made easy! Upload directly to cloud storage and manage your files right from the WordPress Media Library.
- * Version: 3.2.3
+ * Version: 3.2.4
  * Author: Infinite Uploads
  * Author URI: https://infiniteuploads.com/?utm_source=iup_plugin&utm_medium=plugin&utm_campaign=iup_plugin&utm_content=meta
  * Text Domain: infinite-uploads
@@ -18,7 +18,7 @@
  * Copyright 2021-2025 ClikIT, LLC
 */
 
-define( 'INFINITE_UPLOADS_VERSION', '3.2.3' );
+define( 'INFINITE_UPLOADS_VERSION', '3.2.4' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
     require_once __DIR__ . '/vendor/autoload.php';

--- a/infinite-uploads.php
+++ b/infinite-uploads.php
@@ -89,6 +89,14 @@ function infinite_uploads_upgrade() {
 	if ( INFINITE_UPLOADS_VERSION != $folders_installed ) {
 		infinite_uploads_install_folders();
 	}
+
+	// One-time backfill: prior versions excluded /bb-plugin/cache/ entirely, so any
+	// images BB had already cropped before this release were never added to
+	// infinite_uploads_files. Schedule an async walk + queue so the existing
+	// iu_bb_cache_push handler can offload them. Idempotent — flag is set when done.
+	if ( ! get_site_option( 'iup_bb_carveout_backfilled' ) && ! wp_next_scheduled( 'iu_bb_carveout_backfill' ) ) {
+		wp_schedule_single_event( time() + 60, 'iu_bb_carveout_backfill' );
+	}
 }
 
 function infinite_uploads_install() {

--- a/infinite-uploads.php
+++ b/infinite-uploads.php
@@ -94,7 +94,14 @@ function infinite_uploads_upgrade() {
 	// images BB had already cropped before this release were never added to
 	// infinite_uploads_files. Schedule an async walk + queue so the existing
 	// iu_bb_cache_push handler can offload them. Idempotent — flag is set when done.
-	if ( ! get_site_option( 'iup_bb_carveout_backfilled' ) && ! wp_next_scheduled( 'iu_bb_carveout_backfill' ) ) {
+	//
+	// is_main_site() guard: the flag is network-wide (get_site_option), but
+	// `infinite_uploads_upgrade()` runs on every plugins_loaded across every
+	// subsite. Without this guard, multiple subsite requests can each pass the
+	// `wp_next_scheduled` check before any of them actually schedule, racing to
+	// queue duplicate iu_bb_carveout_backfill events. Restricting to the main
+	// site collapses the race to a single scheduler.
+	if ( is_main_site() && ! get_site_option( 'iup_bb_carveout_backfilled' ) && ! wp_next_scheduled( 'iu_bb_carveout_backfill' ) ) {
 		wp_schedule_single_event( time() + 60, 'iu_bb_carveout_backfill' );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 3.2.3
+Stable tag: 3.2.4
 Requires PHP: 8.0
 Contributors: bww
 Tags: cloud storage, offload media, offload, video streaming, cdn
@@ -216,12 +216,23 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 
 == Upgrade Notice ==
 
-3.2.3
+3.2.4
 -------------
 
-* Update: WordPress 7.0 compatibility
+* Fixed: Cropped images created by Beaver Builder in `bb-plugin/cache/` are now offloaded to the cloud and served via CDN.
+* Fixed: A blank front-end page that could occur when the IU Media Folder Gallery module was active in Beaver Builder.
+* Update: Query performance improvements for the Beaver Builder gallery module dropdown and BB cache sync state lookups.
+* Update: Code refactoring and stability improvements for sites using Beaver Builder with the Media Folders feature.
 
 == Changelog ==
+
+3.2.4
+----------------------------------------------------------------------
+
+* Fixed: Cropped images created by Beaver Builder in `bb-plugin/cache/` are now offloaded to the cloud and served via CDN.
+* Fixed: A blank front-end page that could occur when the IU Media Folder Gallery module was active in Beaver Builder.
+* Update: Query performance improvements for the Beaver Builder gallery module dropdown and BB cache sync state lookups.
+* Update: Code refactoring and stability improvements for sites using Beaver Builder with the Media Folders feature.
 
 3.2.3
 ----------------------------------------------------------------------


### PR DESCRIPTION
* Fixed: Cropped images created by Beaver Builder in `bb-plugin/cache/` are now offloaded to the cloud and served via CDN.
* Fixed: A blank front-end page that could occur when the IU Media Folder Gallery module was active in Beaver Builder.
* Update: Query performance improvements for the Beaver Builder gallery module dropdown and BB cache sync state lookups.
* Update: Code refactoring and stability improvements for sites using Beaver Builder with the Media Folders feature.
