### PR TITLE
Fixed 3-pre existing gaps

### DIFF
--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -135,6 +135,13 @@ class InfiniteUploads {
         }
 
         add_filter( 'infinite_uploads_sync_exclusions', [ $this, 'compatibility_exclusions' ] );
+        // User-configured exclusions must reach the scan-time filter too —
+        // without this, a full re-scan uploads files the user has explicitly
+        // marked as excluded (wasting bandwidth/cloud storage), and — worse —
+        // makes those already-synced-but-excluded rows eligible for "Free Up
+        // Local Storage" deletion, producing 404 media (the rewriter keeps
+        // serving the local URL because the path is excluded).
+        add_filter( 'infinite_uploads_sync_exclusions', [ $this, 'user_exclusions' ] );
 
         if ( ! $this->api->has_token() ) {
             add_action( 'admin_notices', [ $this, 'setup_notice' ] );
@@ -499,10 +506,16 @@ class InfiniteUploads {
     public function get_sync_stats() {
         global $wpdb;
 
+        // $deletable must match what "Free Up Local Storage" would actually
+        // delete — otherwise the UI advertises freeable space that BB cache /
+        // user-excluded carve-outs will keep on disk. Same carve-out is applied
+        // to the delete loops (ajax_delete_old, ajax_delete, WP-CLI files delete).
+        $carve_out = InfiniteUploadsHelper::deletable_files_where_carveout();
+
         $total     = $wpdb->get_row( "SELECT count(*) AS files, SUM(`size`) as size, SUM(`transferred`) as transferred FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE 1" );
         $local     = $wpdb->get_row( "SELECT count(*) AS files, SUM(`size`) as size, SUM(`transferred`) as transferred FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE deleted = 0" );
         $synced    = $wpdb->get_row( "SELECT count(*) AS files, SUM(`size`) as size, SUM(`transferred`) as transferred FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1" );
-        $deletable = $wpdb->get_row( "SELECT count(*) AS files, SUM(`size`) as size, SUM(`transferred`) as transferred FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0" );
+        $deletable = $wpdb->get_row( "SELECT count(*) AS files, SUM(`size`) as size, SUM(`transferred`) as transferred FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0{$carve_out}" );
         $deleted   = $wpdb->get_row( "SELECT count(*) AS files, SUM(`size`) as size, SUM(`transferred`) as transferred FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 1" );
 
         $progress = (array) get_site_option( 'iup_files_scanned' );
@@ -2001,6 +2014,23 @@ class InfiniteUploads {
         $root_dirs = $this->get_original_upload_dir_root();
 
         return $root_dirs['basedir'] . substr( $folder, strlen( $cloud_base ) );
+    }
+
+    /**
+     * Merge the user's own excluded-paths list (option `iup_excluded_files`)
+     * into the sync-exclusion filter. This is what makes full re-scans stop
+     * queuing user-excluded files for upload; per-file un-exclude still
+     * re-syncs via process_added_removed_excluded_files() → add_files_to_sync(),
+     * which iterates $paths_left directly and does not consult is_excluded(),
+     * so re-syncing an un-excluded file still works.
+     */
+    function user_exclusions( $exclusions ) {
+        $user = InfiniteUploadsHelper::get_excluded_paths();
+        if ( ! empty( $user ) ) {
+            $exclusions = array_merge( $exclusions, $user );
+        }
+
+        return $exclusions;
     }
 
     /**

--- a/inc/InfiniteUploadsAdmin.php
+++ b/inc/InfiniteUploadsAdmin.php
@@ -1320,13 +1320,12 @@ class InfiniteUploadsAdmin {
         $errors  = [];
         $path    = $this->iup_instance->get_original_upload_dir_root();
         $break   = false;
-        // SQL-side carve-out: BB cache images are offloaded for CDN delivery but must
-        // STAY on local disk too — if we delete them, Beaver Builder will regenerate
-        // them on the next request, creating a churn cycle (new file → sync → delete →
-        // regen). Skipping at the SELECT level keeps the loop progressing (no infinite
-        // re-fetch of unprocessed rows) and matches the carve-out applied at scan time
-        // in InfiniteUploadsHelper::is_offloadable_bb_cache_image().
-        $carve_out_sql = " AND file NOT LIKE '%/bb-plugin/cache/%'";
+        // SQL-side carve-outs: BB cache images (regeneration churn) and user-excluded
+        // paths (rewriter serves the LOCAL URL, so removing the local copy would 404
+        // the media). Applied at SELECT level so the loop progresses and the count
+        // matches the actual delete targets. See
+        // InfiniteUploadsHelper::deletable_files_where_carveout().
+        $carve_out_sql = InfiniteUploadsHelper::deletable_files_where_carveout();
         while ( ! $break ) {
             $to_delete = $wpdb->get_col( "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0{$carve_out_sql} LIMIT 500" );
             foreach ( $to_delete as $file ) {
@@ -1385,12 +1384,18 @@ class InfiniteUploadsAdmin {
             $this->ajax_timelimit = max( 20, floor( $max_execution_time * 0.6666 ) );
         }
 
+        // Match the ajax_delete_old carve-outs so BB cache images (churn) and
+        // user-excluded paths (rewriter serves the LOCAL URL — deleting the
+        // local copy would 404 the media) stay on disk. See
+        // InfiniteUploadsHelper::deletable_files_where_carveout().
+        $carve_out_sql = InfiniteUploadsHelper::deletable_files_where_carveout();
+
         while ( ! $break ) {
             // PERFORMANCE: Optimized query with proper preparation
             $to_delete = $wpdb->get_results(
                     $wpdb->prepare(
-                            "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` 
-                WHERE synced = 1 AND deleted = 0 
+                            "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files`
+                WHERE synced = 1 AND deleted = 0{$carve_out_sql}
                 LIMIT %d",
                             $batch_size
                     ),
@@ -1406,8 +1411,8 @@ class InfiniteUploadsAdmin {
 
                 // PERFORMANCE: More efficient count check
                 $remaining = (int) $wpdb->get_var(
-                        "SELECT COUNT(*) FROM `{$wpdb->base_prefix}infinite_uploads_files` 
-                WHERE synced = 1 AND deleted = 0"
+                        "SELECT COUNT(*) FROM `{$wpdb->base_prefix}infinite_uploads_files`
+                WHERE synced = 1 AND deleted = 0{$carve_out_sql}"
                 );
 
                 $is_done = ( $remaining === 0 );

--- a/inc/InfiniteUploadsFilelist.php
+++ b/inc/InfiniteUploadsFilelist.php
@@ -173,6 +173,26 @@ class InfiniteUploadsFilelist {
 				$path = rtrim( $this->root_path, '/' ) . $path;
 			}
 
+			// Un-exclude flow (process_added_removed_excluded_files → new
+			// InfiniteUploadsFilelist($path, 20, $files_to_resync)) passes
+			// individual FILE paths in $paths_left. The glob() branch below
+			// treats every path as a directory pattern — glob() on a file
+			// returns [], so the file would be silently skipped and never
+			// re-queued for sync. Handle files directly first.
+			if ( is_file( $path ) ) {
+				if ( ! is_link( $path ) ) {
+					if ( is_readable( $path ) ) {
+						$file         = $this->get_file_info( $path );
+						$file['name'] = $this->relative_path( $path );
+						$this->add_file( $file );
+					} else {
+						error_log( sprintf( '[INFINITE_UPLOADS Filelist Error] %s could not be read for syncing', $path ) );
+					}
+				}
+				$this->paths_left = $paths;
+				continue;
+			}
+
 			$contents = defined( 'GLOB_BRACE' )
 				? glob( trailingslashit( $path ) . '{,.}[!.,!..]*', GLOB_BRACE )
 				: glob( trailingslashit( $path ) . '[!.,!..]*' );

--- a/inc/InfiniteUploadsHelper.php
+++ b/inc/InfiniteUploadsHelper.php
@@ -47,6 +47,36 @@ class InfiniteUploadsHelper {
 	}
 
 	/**
+	 * Build the SQL fragment that carves files out of the "deletable" set
+	 * used by "Free Up Local Storage" (the delete loop + the deletable-count
+	 * stat). The fragment starts with " AND ..." so it can be concatenated
+	 * directly after a `WHERE synced = 1 AND deleted = 0` clause.
+	 *
+	 * Two things must stay on local disk even after they're synced:
+	 *
+	 * 1. Beaver Builder cache images (`/bb-plugin/cache/`) — BB regenerates
+	 *    missing files on the next request, creating a sync/delete churn
+	 *    (new file → scan → sync → free-up-deletes → regen → repeat).
+	 *
+	 * 2. User-excluded paths — the rewriter is told to serve the LOCAL URL
+	 *    for excluded files; deleting the local copy while keeping the row
+	 *    marked synced produces 404 media until the file is re-downloaded.
+	 *
+	 * @return string SQL fragment (prefixed with " AND ...") safe to append
+	 *                to an existing WHERE clause.
+	 */
+	public static function deletable_files_where_carveout() {
+		global $wpdb;
+
+		$sql = " AND file NOT LIKE '%/bb-plugin/cache/%'";
+		foreach ( self::get_excluded_paths() as $ex ) {
+			$sql .= $wpdb->prepare( ' AND file NOT LIKE %s', '%' . $wpdb->esc_like( $ex ) . '%' );
+		}
+
+		return $sql;
+	}
+
+	/**
 	 * Get the list of excluded files from the WordPress option.
 	 *
 	 * @return array|false An array of excluded file paths.

--- a/inc/InfiniteUploadsWPCLICommand.php
+++ b/inc/InfiniteUploadsWPCLICommand.php
@@ -439,12 +439,14 @@ class InfiniteUploadsWPCLICommand extends \WP_CLI_Command {
 		}
 
 		//begin deleting
-		// Carve-out: BB cache images are offloaded but must stay local (BB regenerates
-		// missing files → sync churn). Filter at SELECT level so the count and progress
-		// bar reflect actual delete targets. Matches the scan-time carve-out in
-		// InfiniteUploadsHelper::is_offloadable_bb_cache_image().
+		// Carve-outs: BB cache images (BB regenerates → sync churn) and user-excluded
+		// paths (rewriter serves the LOCAL URL, so deleting the local copy 404s the
+		// media). Filter at SELECT level so the count and progress bar reflect the
+		// actual delete targets.
+		// See InfiniteUploadsHelper::deletable_files_where_carveout().
 		$deleted      = 0;
-		$to_delete    = $wpdb->get_col( "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0 AND file NOT LIKE '%/bb-plugin/cache/%'" );
+		$carve_out    = InfiniteUploadsHelper::deletable_files_where_carveout();
+		$to_delete    = $wpdb->get_col( "SELECT file FROM `{$wpdb->base_prefix}infinite_uploads_files` WHERE synced = 1 AND deleted = 0{$carve_out}" );
 		$progress_bar = null;
 		if ( ! $args_assoc['verbose'] ) {
 			$progress_bar = \WP_CLI\Utils\make_progress_bar( esc_html__( 'Deleting local copies of synced files...', 'infinite-uploads' ), count( $to_delete ) );


### PR DESCRIPTION
- Fixed Un-excluding a single file never re-syncs it
- Free Up Local Storage deletes excluded files
- User exclusions never reach the scan-time filter