### PR TITLE
WP All Import Pro compatibility: keep the functions file on local disk

### DIFF
--- a/inc/InfiniteUploads.php
+++ b/inc/InfiniteUploads.php
@@ -1952,6 +1952,21 @@ class InfiniteUploads {
         // cache. See alm_cache_path() for why this one is written against the
         // published filter rather than the (commercial) add-on source.
         add_filter( 'alm_cache_path', [ $this, 'alm_cache_path' ] );
+
+        // WP All Import Pro: its Function Editor writes a PHP file to
+        // uploads/wpallimport/functions.php and loads it with require_once() on
+        // every admin request that renders an import screen. Same
+        // allow_url_include wall as WP Webhooks Pro above, but this one fatals
+        // in the admin rather than on the front end, which locks the user out
+        // of All Import entirely. `import_functions_file_path` (verified in Pro
+        // 4.11) is applied at all four sites that touch the file --
+        // setup_allimport_dir()'s @touch, CodeBox::requireFunctionsFile()'s
+        // require_once, CodeBox::revertToFunctionsFile()'s rename, and the
+        // wp_ajax_save_import_functions save handler -- so this single filter
+        // covers create, read, write and revert. The _backup.php sibling is
+        // derived from the filtered value, so it follows automatically.
+        // /wpallimport/ is in our sync exclusions so the whole tree stays local.
+        add_filter( 'import_functions_file_path', [ $this, 'wpai_functions_file_path' ] );
     }
 
     /**
@@ -2102,6 +2117,32 @@ class InfiniteUploads {
     }
 
     /**
+     * Map the WP All Import Pro functions file from the iu:// stream wrapper
+     * back to the original local uploads path.
+     *
+     * WP All Import builds this as uploads/wpallimport/functions.php from
+     * wp_upload_dir() and require_once()s it from
+     * Wpai\Integrations\CodeBox::requireFunctionsFile() on admin_init, so a
+     * cloud-backed path takes down every All Import admin screen with
+     * "iu:// wrapper is disabled in the server configuration by
+     * allow_url_include=0" rather than failing quietly.
+     *
+     * The filter also fires on the create/save/revert paths, so the file is
+     * authored on local disk in the first place and never lands in the bucket.
+     * The free WP All Import has no Function Editor and never applies this
+     * filter, so that install is unaffected.
+     *
+     * Hooked to `import_functions_file_path`.
+     *
+     * @param string $functions Absolute path to WP All Import's functions.php.
+     *
+     * @return string Local-disk equivalent of $functions, or $functions unchanged.
+     */
+    public function wpai_functions_file_path( $functions ) {
+        return $this->cloud_path_to_local( $functions );
+    }
+
+    /**
      * Merge the user's own excluded-paths list (option `iup_excluded_files`)
      * into the sync-exclusion filter. This is what makes full re-scans stop
      * queuing user-excluded files for upload; per-file un-exclude still
@@ -2143,6 +2184,13 @@ class InfiniteUploads {
         // Ajax Load More Cache add-on's per-query static cache — local-only,
         // and pointless to sync. See alm_cache_path().
         $exclusions[] = '/alm-cache/';
+        // WP All Import Pro's working tree. functions.php must stay local
+        // because PHP can't require_once() through the iu:// wrapper (see
+        // wpai_functions_file_path()), and the sibling logs/, files/, temp/,
+        // uploads/ and history/ folders are import scratch space: chunked
+        // writes, large source files and per-run logs that are churn to sync
+        // and are deleted again once the import finishes.
+        $exclusions[] = '/wpallimport/';
 
         return $exclusions;
     }

--- a/tests/Unit/WpaiFunctionsFilePathTest.php
+++ b/tests/Unit/WpaiFunctionsFilePathTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Tests for the WP All Import Pro functions-file compatibility filter.
+ *
+ * WP All Import Pro's Function Editor stores user PHP in
+ * uploads/wpallimport/functions.php and loads it with require_once() from
+ * Wpai\Integrations\CodeBox::requireFunctionsFile(), which runs on admin_init
+ * for every All Import screen. The path comes from wp_upload_dir(), which IU
+ * rewrites to iu://, and PHP refuses to include through a URL stream wrapper
+ * unless allow_url_include is on -- which it must never be, since that would
+ * let anyone able to place a .php file in the bucket execute it. The result is
+ * a hard fatal that locks the user out of All Import entirely, so
+ * wpai_functions_file_path() must map the file back to local disk.
+ *
+ * It hooks `import_functions_file_path`, the single filter WP All Import
+ * applies at all four sites that touch the file (verified in Pro 4.11):
+ * setup_allimport_dir()'s @touch, CodeBox::requireFunctionsFile()'s
+ * require_once, CodeBox::revertToFunctionsFile()'s rename, and the
+ * wp_ajax_save_import_functions save handler.
+ *
+ * Path conventions (from tests/bootstrap.php):
+ *   WP_CONTENT_DIR = sys_get_temp_dir() . '/iu-tests-wp-content'
+ *   local basedir  = WP_CONTENT_DIR . '/uploads'
+ *
+ * @package ClikIT\InfiniteUploads\Tests\Unit
+ */
+
+declare( strict_types=1 );
+
+namespace ClikIT\InfiniteUploads\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use ClikIT\InfiniteUploads\InfiniteUploads;
+use ClikIT\InfiniteUploads\Tests\TestCase;
+
+/**
+ * Runs in separate processes: the rest of the unit suite loads the lightweight
+ * InfiniteUploads stub from tests/fixtures/ewww-environment.php, and PHP can't
+ * hold both that stub and the real class (same FQCN) in one process. A fresh
+ * process lets the autoloader resolve the REAL inc/InfiniteUploads.php, which
+ * is where wpai_functions_file_path() and compatibility_exclusions() live.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class WpaiFunctionsFilePathTest extends TestCase {
+
+	private const BUCKET = 'iup-usa/4202/wv9s0vwv';
+
+	/**
+	 * @var InfiniteUploads
+	 */
+	private $instance;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Functions\when( 'untrailingslashit' )->alias(
+			static function ( $s ) {
+				return rtrim( (string) $s, '/' );
+			}
+		);
+		Functions\when( 'is_multisite' )->justReturn( false );
+		// get_option('upload_path') returns '' → basedir falls through to WP_CONTENT_DIR/uploads.
+		Functions\when( 'get_option' )->alias(
+			static function ( $key, $default = false ) {
+				return $default;
+			}
+		);
+
+		$this->instance         = new InfiniteUploads();
+		$this->instance->bucket = self::BUCKET;
+	}
+
+	private function local_basedir(): string {
+		return WP_CONTENT_DIR . '/uploads';
+	}
+
+	/**
+	 * The reported failure: the exact path from the customer's fatal.
+	 */
+	public function test_maps_cloud_functions_file_to_local_uploads_path(): void {
+		$this->assertSame(
+			$this->local_basedir() . '/wpallimport/functions.php',
+			$this->instance->wpai_functions_file_path(
+				'iu://' . self::BUCKET . '/wpallimport/functions.php'
+			)
+		);
+	}
+
+	/**
+	 * CodeBox derives the backup file by str_replace()ing '.php' on the already
+	 * filtered value, so it must map cleanly too.
+	 */
+	public function test_maps_the_backup_functions_file(): void {
+		$this->assertSame(
+			$this->local_basedir() . '/wpallimport/functions_backup.php',
+			$this->instance->wpai_functions_file_path(
+				'iu://' . self::BUCKET . '/wpallimport/functions_backup.php'
+			)
+		);
+	}
+
+	public function test_preserves_multisite_subpath_under_the_bucket(): void {
+		$this->assertSame(
+			$this->local_basedir() . '/sites/7/wpallimport/functions.php',
+			$this->instance->wpai_functions_file_path(
+				'iu://' . self::BUCKET . '/sites/7/wpallimport/functions.php'
+			)
+		);
+	}
+
+	public function test_handles_bucket_with_trailing_slash(): void {
+		$this->instance->bucket = self::BUCKET . '/';
+
+		$this->assertSame(
+			$this->local_basedir() . '/wpallimport/functions.php',
+			$this->instance->wpai_functions_file_path(
+				'iu://' . self::BUCKET . '/wpallimport/functions.php'
+			)
+		);
+	}
+
+	/**
+	 * A site that is not offloaded, or one where the user has already pointed
+	 * the filter somewhere else, must pass through untouched.
+	 */
+	public function test_leaves_local_path_untouched(): void {
+		$local = $this->local_basedir() . '/wpallimport/functions.php';
+
+		$this->assertSame( $local, $this->instance->wpai_functions_file_path( $local ) );
+	}
+
+	public function test_leaves_other_buckets_untouched(): void {
+		$other = 'iu://iup-eu/9999/otherbucket/wpallimport/functions.php';
+
+		$this->assertSame( $other, $this->instance->wpai_functions_file_path( $other ) );
+	}
+
+	public function test_sync_exclusions_include_wpallimport_folder(): void {
+		$this->assertContains( '/wpallimport/', $this->instance->compatibility_exclusions( [] ) );
+	}
+
+	/**
+	 * The compatibility path filters all share cloud_path_to_local(); this pins
+	 * that they stay behaviourally identical so a future edit to one can't
+	 * silently diverge from the others.
+	 */
+	public function test_all_compat_path_filters_agree(): void {
+		$cloud = 'iu://' . self::BUCKET . '/some-plugin-dir';
+		$local = $this->local_basedir() . '/some-plugin-dir';
+
+		$this->assertSame( $local, $this->instance->wpai_functions_file_path( $cloud ) );
+		$this->assertSame( $local, $this->instance->alm_repeater_path( $cloud ) );
+		$this->assertSame( $local, $this->instance->alm_cache_path( $cloud ) );
+		$this->assertSame( $local, $this->instance->wpwh_folder_base( $cloud ) );
+	}
+}


### PR DESCRIPTION
Reported by a customer on staging.christianfinancialadvisors.com (FreeScout #11348). Third instance of the same `allow_url_include` failure after WP Webhooks Pro and Ajax Load More, and it reuses their `cloud_path_to_local()` helper.

## The failure

Every WP All Import admin screen fataled:

```
Warning: require_once(): iu:// wrapper is disabled in the server configuration by
allow_url_include=0 in .../wp-all-import-pro/src/Integrations/CodeBox.php on line 91

Fatal error: Uncaught Error: Failed opening required
'iu://iup-usa/4202/wv9s0vwv/wpallimport/functions.php'
```

## Root cause

WP All Import Pro's Function Editor stores user PHP in `uploads/wpallimport/functions.php` and `require_once()`s it from `Wpai\Integrations\CodeBox::requireFunctionsFile()`, which runs on `admin_init`. The path is built from `wp_upload_dir()`, which we rewrite to `iu://`, and PHP refuses to include through a URL stream wrapper unless `allow_url_include` is enabled.

That must never be enabled: it would let anyone able to place a `.php` file in the bucket execute it. So the file has to stay on local disk.

Worse than the previous two, which failed on one operation. This one fires on `admin_init` and locks the user out of All Import entirely.

## The fix

Hook `import_functions_file_path` and map the file back to the original local uploads path.

Verified against the Pro source that the filter is applied at all four sites that touch the file, so a single filter covers create, read, write and revert:

| Site | Operation |
|---|---|
| `setup_allimport_dir()` | `@touch` creates it |
| `CodeBox::requireFunctionsFile()` | `require_once` — the reported fatal |
| `CodeBox::revertToFunctionsFile()` | `rename` |
| `actions/wp_ajax_save_import_functions.php` | save handler |

The `_backup.php` sibling is derived from the filtered value via `str_replace`, so it follows automatically. The free WP All Import has no Function Editor and never applies this filter, so that install is unaffected.

Also excludes `/wpallimport/` from sync. Beyond `functions.php` the tree holds `logs/`, `files/`, `temp/`, `uploads/` and `history/` — import scratch space: chunked writes, large source files and per-run logs that are churn to sync and get deleted again when the import finishes. Relevant because the stream wrapper only accepts `r`, `w`, `a`, `x` and rejects every `+` mode, which is what broke Ajax Load More.

## Tests

`tests/Unit/WpaiFunctionsFilePathTest.php`, 8 tests, modelled on `AlmRepeaterPathTest`. Covers the customer's exact failing path, the backup sibling, multisite subpaths, trailing-slash buckets, pass-through for local paths and other buckets, the sync exclusion, and that all four compat path filters stay behaviourally identical.

Full suite: 275 tests, 371 assertions, passing.

## Verified on a live install

Built a zip from this branch and installed it on a SandyWP sandbox. Activated cleanly, AWS SDK autoloads, gallery block assets present, no fatals. Confirmed on the running site that the filter registers once `plugin_compatibility()` runs and maps every relevant path:

```
iu://…/wpallimport/functions.php         -> /var/www/html/wp-content/uploads/wpallimport/functions.php
iu://…/wpallimport/functions_backup.php  -> /var/www/html/wp-content/uploads/wpallimport/functions_backup.php
iu://…/sites/7/wpallimport/functions.php -> /var/www/html/wp-content/uploads/sites/7/wpallimport/functions.php
already-local path                        -> unchanged
different bucket                          -> unchanged
```

Registration sits inside `setup()`, which only runs on a connected site. That matches the existing WP Webhooks and ALM shims: on a non-offloaded site there is no `iu://` path to correct.

## Note

A hotfix build of this branch (`3.3.1-hotfix.1`) has been sent to the reporting customer ahead of release.
